### PR TITLE
Remove broken hover link from managed term

### DIFF
--- a/website/docs/terms/hover-terms.md
+++ b/website/docs/terms/hover-terms.md
@@ -101,10 +101,7 @@ lsp:
 
 managed:
   displayText: managed
-  hoverSnippet: dbt Labs manages the AI provider connection; no user provider key is required. Refer to
-  hoverLink: /docs/dbt-ai/wizard-billing-faqs
-  hoverLinkText: Billing
-  hoverLinkSuffix: for more info.
+  hoverSnippet: dbt Labs manages the AI provider connection; no user provider key is required.
 
 
 materialization:


### PR DESCRIPTION
The `managed` hover tooltip renders a link to the Wizard billing FAQs, but the link doesn't render properly in the tooltip and isn't useful there.

Removes `hoverLink`, `hoverLinkText`, and `hoverLinkSuffix` so the tooltip ends at "no user provider key is required."