### PR TITLE
Document reattaching by invocation ID

### DIFF
--- a/website/docs/reference/commands/invocation.md
+++ b/website/docs/reference/commands/invocation.md
@@ -78,6 +78,14 @@ Active Invocations:
 ➜  jaffle-shop git:(test-cli) ✗ 
 ```
 
+To reattach to a specific active invocation, copy its `ID` and pass it to the `--id` flag:
+
+```shell
+dbt reattach --id 6dcf4723-e057-48b5-946f-a4d87e1d117a
+```
+
+If you omit `--id`, dbt reattaches to the most recent invocation.
+
 :::tip
 
 To cancel an active session in the terminal, use the `Ctrl + Z` shortcut.
@@ -88,5 +96,3 @@ To cancel an active session in the terminal, use the `Ctrl + Z` shortcut.
 
 - [Install <Constant name="dbt" /> CLI](/docs/platform/dbt-cli-installation)
 - [Troubleshooting <Constant name="dbt" /> CLI 'Session occupied' error](/faqs/Troubleshooting/long-sessions-dbt-cli)
-
-


### PR DESCRIPTION
## What are you changing in this pull request and why?

Clarify what to do with the ID returned by `dbt invocation list`. The page now shows how to reattach to a specific active invocation with `dbt reattach --id` and explains that omitting `--id` selects the most recent invocation.

This fills the missing step between listing active invocations and managing one of them.

## Checklist

- [x] The changes in this PR meet the docs style guide/fundamentals required for all content.
- [x] Versioning isn't required because this clarifies existing dbt platform CLI behavior.
- [x] A release note isn't required because this doesn't change product behavior.

## Validation

- [x] `npm run lint -- docs/reference/commands/invocation.md`
- [x] `DOCS_ENV=build npm run build`
