### PR TITLE
[dbt State] dbt state explain

### DIFF
--- a/website/docs/docs/dbt-versions/release-notes.md
+++ b/website/docs/docs/dbt-versions/release-notes.md
@@ -22,7 +22,7 @@ For <Constant name="fusion_engine" /> updates, refer to the [dbt-fusion changelo
 
 ## August 2026
 
-- **New:** When dbt State is enabled, you can run `dbt state explain` (<Constant name="core_v2" />) or `dbt-state explain` (<Constant name="core" /> plugin) in the CLI after a job finishes to see why dbt State made each decision and whether each node was built, reused, or cloned. For a detailed breakdown, run the command with `--verbose -s my_node_name` to see the table analysis, query analysis, and data freshness steps for a specific node. For more information, refer to [`dbt state explain`](/reference/commands/state-explain).
+- **New:** When dbt State is enabled, you can run `dbt state explain` (<Constant name="core_v2" />) or `dbt-state explain` (<Constant name="core" /> plugin) in the CLI after a job finishes to see why dbt State made each decision and whether each node was built, reused, or cloned. For a detailed breakdown, run the command with `--verbose -s my_node_name` to see the table analysis, query analysis, and data freshness analysis for a specific node. For more information, refer to [`dbt state explain`](/reference/commands/state-explain).
 - **Enhancement:** New sessions open on the Wizard tab when available, and the <Constant name="studio_ide" /> remembers your last-used tab for each project so you can pick up where you left off.
 - **Enhancement:** A new `relationName` field on the `ModelAppliedStateNode` and `ModelAppliedStateNestedNode` GraphQL types exposes the fully-qualified, adapter-rendered relation name (for example, `"database"."schema"."model_name"`) from the last successful model build.
 

--- a/website/docs/docs/dbt-versions/release-notes.md
+++ b/website/docs/docs/dbt-versions/release-notes.md
@@ -22,6 +22,7 @@ For <Constant name="fusion_engine" /> updates, refer to the [dbt-fusion changelo
 
 ## August 2026
 
+- **New:** When dbt State is enabled, you can run `dbt state explain` (<Constant name="core_v2" />) or `dbt-state explain` (<Constant name="core" /> plugin) in the CLI after a job finishes to see why dbt State made each decision and whether each node was built, reused, or cloned. For a detailed breakdown, run the command with `--verbose -s my_node_name` to see the table analysis, query analysis, and data freshness steps for a specific node. For more information, refer to [`dbt state explain`](/reference/commands/state-explain).
 - **Enhancement:** New sessions open on the Wizard tab when available, and the <Constant name="studio_ide" /> remembers your last-used tab for each project so you can pick up where you left off.
 - **Enhancement:** A new `relationName` field on the `ModelAppliedStateNode` and `ModelAppliedStateNestedNode` GraphQL types exposes the fully-qualified, adapter-rendered relation name (for example, `"database"."schema"."model_name"`) from the last successful model build.
 

--- a/website/docs/docs/deploy/dbt-state-about.md
+++ b/website/docs/docs/deploy/dbt-state-about.md
@@ -40,6 +40,8 @@ When you run a command like `dbt build --select +my_model`, dbt State evaluates 
 
 Without dbt State, every selected node rebuilds on every run regardless of whether anything has changed.
 
+To see which decision dbt State made for each node after a run and why, you can run the <VersionBlock firstVersion="2.0">[`dbt state explain`](/reference/commands/state-explain)</VersionBlock><VersionBlock lastVersion="1.99">[`dbt-state explain`](/reference/commands/state-explain)</VersionBlock> command.
+
 For the full list of available configs, see [dbt State configs](/reference/resource-configs/dbt-state-configs).
 
 <Expandable alt_header="How dbt State decides whether to rebuild, clone, or reuse">

--- a/website/docs/docs/deploy/dbt-state-setup.md
+++ b/website/docs/docs/deploy/dbt-state-setup.md
@@ -158,6 +158,8 @@ If dbt State is behaving unexpectedly, you can prepend your run command with the
 DBT_ENGINE_MANAGE_STATE=0 dbt run --target dev --select "customers"
 ```
 
+To see which decision dbt State made for each node after a run and why, you can run the <VersionBlock firstVersion="2.0">[`dbt state explain`](/reference/commands/state-explain)</VersionBlock><VersionBlock lastVersion="1.99">[`dbt-state explain`](/reference/commands/state-explain)</VersionBlock> command.
+
 ## Next steps
 
 - [Migrate from state-aware orchestration](/docs/deploy/dbt-state-migration)

--- a/website/docs/faqs/State/views-rebuilt.md
+++ b/website/docs/faqs/State/views-rebuilt.md
@@ -65,9 +65,25 @@ To prevent external sources from always being considered stale, configure [`load
 
 ## How to diagnose
 
-In <Constant name="core" /> v1.7–v1.12, run the `dbt-state explain` command to see why dbt State rebuilt or reused a specific model.
+After a run, use <VersionBlock firstVersion="2.0">[`dbt state explain`](/reference/commands/state-explain)</VersionBlock><VersionBlock lastVersion="1.99">[`dbt-state explain`](/reference/commands/state-explain)</VersionBlock> to see why dbt State rebuilt, reused, or cloned a specific model. For a detailed breakdown, use the `--verbose` flag with `-s` to select your model:
 
-:::caution Experimental
-The `dbt-state explain` command is experimental. It isn't available in the <Constant name="fusion_engine" /> or <Constant name="dbt_platform" /> yet.
+:::note
+The command name differs by version: <Constant name="core_v2" /> uses `dbt state explain` (with a space), while <Constant name="core_v1" /> uses `dbt-state explain` (with a hyphen).
 :::
+
+<VersionBlock firstVersion="2.0">
+
+```bash
+dbt state explain --verbose -s my_model_name
+```
+
+</VersionBlock>
+
+<VersionBlock lastVersion="1.99">
+
+```bash
+dbt-state explain --verbose -s my_model_name
+```
+
+</VersionBlock>
 

--- a/website/docs/reference/commands/state-explain.md
+++ b/website/docs/reference/commands/state-explain.md
@@ -1,0 +1,165 @@
+---
+title: "dbt state explain"
+sidebar_label: "state explain"
+id: "state-explain"
+description: "Use dbt state explain to see why dbt State made each decision after a run."
+---
+
+<VersionBlock firstVersion="2.0">`dbt state explain`</VersionBlock><VersionBlock lastVersion="1.99">`dbt-state explain`</VersionBlock> is a CLI command available when you enable [dbt State](/docs/deploy/dbt-state-about). After a job finishes, run this command to see why dbt State made each decision for every node and whether it executed, skipped, or cloned the node. Use it to audit State behavior, debug unexpected skips, or confirm that freshness and query checks work as expected.
+
+<VersionBlock firstVersion="2.0">
+
+```bash
+dbt state explain
+```
+
+The output shows all nodes from the last run, with a summary of the State decision for each:
+
+<!--example not yet final, im still seeing the same thing with or without --verbose -->
+```shell
+SKIP_EXECUTION model.jaffle_shop.customers - model was a no-op because its query is up to date and its upstream data is within freshness tolerance
+READY_TO_EXECUTE model.jaffle_shop.orders - model was executed because the view definition is newer than the cached execution
+READY_TO_EXECUTE test.jaffle_shop.not_null_customers_customer_id - data test was executed because it has no prior execution or its query changed
+UNKNOWN unit_test.jaffle_shop.orders.test_order_items_compute_to_bools_correctly - dbt State explain details unavailable
+```
+
+</VersionBlock>
+
+<VersionBlock lastVersion="1.99">
+
+```bash
+dbt-state explain
+```
+
+The output shows all nodes from the last run with a summary of the State decision for each:
+
+```shell
+Last run: 2 minutes ago
+
+customers
+└── [No-op] model was a no-op because its query is up to date and its upstream data is within freshness tolerance
+
+locations
+└── [Execute] model was executed because either its query didn't match or its upstream data is out of date
+
+not_null_stg_locations_location_id
+└── [Execute] data test was executed because it has no prior execution or its query changed
+```
+
+
+</VersionBlock>
+
+## Specifying a log file
+
+By default, <VersionBlock firstVersion="2.0">`dbt state explain`</VersionBlock><VersionBlock lastVersion="1.99">`dbt-state explain`</VersionBlock> reads from the most recent execution. To analyze a previous run, you can use `--log-file` (or `-l`) to specify a state file from the `logs/state/` directory:
+
+<VersionBlock firstVersion="2.0">
+
+```bash
+dbt state explain --log-file 'logs/state/responses_2026_08_25_11_00_15_667.jsonl'
+```
+
+</VersionBlock>
+
+<VersionBlock lastVersion="1.99">
+
+```bash
+dbt-state explain --log-file 'logs/state/responses_2026_08_25_11_00_15_667.jsonl'
+```
+
+</VersionBlock>
+
+## Using verbose mode
+
+Use the `--verbose` flag to see the full step-by-step analysis for each node and add a run configuration summary. Use `-s` to filter the output to a specific node.
+
+<VersionBlock firstVersion="2.0">
+
+```bash
+dbt state explain --verbose -s my_node_name
+```
+
+In <Constant name="core_v2" />, `--verbose` adds a run configuration summary at the top and shows the full step-by-step analysis for each node.
+
+```shell
+Run configuration:
+  - started at: 2026-08-17T12:24:15.822733+00:00
+  - profile: my_profile
+  - target: dev
+  - defer to target: prod
+  - freshness tolerance: 2700 seconds
+  - tolerate nondeterminism: true
+  - clone incremental in dev: IF_TABLE_MISSING
+  - metadata cache TTL: 0 seconds
+  - select: fqn:my_node_name
+SKIP_EXECUTION model.jaffle_shop.customers - model was a no-op because its query is up to date and its upstream data is within freshness tolerance
+  - table analysis ("ANALYTICS"."MY_SCHEMA"."CUSTOMERS")
+    - the model table exists already [SUCCESS, TARGET_TABLE_EXISTS]
+  - query analysis
+    - the model query has not changed [SUCCESS, NODE_QUERY_UNCHANGED]
+    - upstream model queries have not changed [SUCCESS]
+  - data freshness analysis
+    - upstream dependencies
+      - "ANALYTICS"."MY_SCHEMA_RAW"."RAW_CUSTOMERS" [FRESH]
+        - no updates since "ANALYTICS"."MY_SCHEMA"."CUSTOMERS" last executed
+        - last updated: 5 days ago
+    - upstream data is up to date [SUCCESS]
+```
+
+</VersionBlock>
+
+<VersionBlock lastVersion="1.99">
+
+```bash
+dbt-state explain --verbose -s my_node_name
+```
+
+The verbose output shows the full step-by-step analysis and adds a run configuration summary:
+
+```shell
+Last run: 2026-08-19 20:19:00 PST (10 minutes ago)
+
+  Run configuration:
+  ├── dbt State:
+  │   ├── defer to target: prod
+  │   ├── freshness tolerance: 45 minutes (2700 seconds)
+  │   ├── tolerate non-determinism: True
+  │   ├── clone incremental in dev: IF_TABLE_MISSING
+  │   └── metadata cache ttl: infinite (cache never expires)
+  └── dbt:
+      ├── profile: jaffle_shop
+      └── target: dev
+
+  customers
+  ├── table analysis ("ANALYTICS"."DBT_SCHEMA"."CUSTOMERS")
+  │   └── ✓ the model table exists already in 'dev'
+  ├── query analysis
+  │   ├── ✓ the model query has not changed
+  │   └── ✓ upstream model queries have not changed
+  └── data freshness analysis
+      ├── upstream dependencies
+      │   ├── [fresh] "ANALYTICS"."RAW"."RAW_CUSTOMERS"
+      │   │   ├── no updates since "ANALYTICS"."DBT_SCHEMA"."CUSTOMERS" last
+      │   │   │   executed
+      │   │   └── last updated: a month ago, 2026-07-31 13:22:30 UTC
+      │   └── [within tolerance] "ANALYTICS"."DBT_SCHEMA"."ORDERS"
+      │       ├── updated a moment after "ANALYTICS"."DBT_SCHEMA"."CUSTOMERS" last
+      │       │   executed (tolerance: 45 minutes)
+      │       └── last updated: 39 seconds ago, 2026-08-19 12:18:40 UTC
+      └── ✓ upstream data is outdated (within tolerance)
+  decision: [No-op] model was a no-op because its query is up to date and its upstream data is within freshness tolerance
+```
+
+</VersionBlock>
+
+The `--verbose` flag produces a decision breakdown that may include the following analyses, depending on the node type:
+
+- **Table analysis**: whether the target table already exists in the schema
+- **Query analysis**: whether the model query or its upstream queries have changed
+- **Data freshness analysis**: whether upstream data is fresh or within the configured [`lag_tolerance`](/reference/resource-configs/lag-tolerance)
+
+## Related docs
+
+- [About dbt State](/docs/deploy/dbt-state-about)
+- [Monitor dbt State activity](/docs/deploy/dbt-state-interface)
+- [dbt State configs](/reference/resource-configs/dbt-state-configs)

--- a/website/docs/reference/commands/state-explain.md
+++ b/website/docs/reference/commands/state-explain.md
@@ -15,7 +15,6 @@ dbt state explain
 
 The output shows all nodes from the last run, with a summary of the State decision for each:
 
-<!--example not yet final, im still seeing the same thing with or without --verbose -->
 ```shell
 SKIP_EXECUTION model.jaffle_shop.customers - model was a no-op because its query is up to date and its upstream data is within freshness tolerance
 READY_TO_EXECUTE model.jaffle_shop.orders - model was executed because the view definition is newer than the cached execution

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1584,6 +1584,7 @@ const sidebarSettings = {
             "reference/commands/show",
             "reference/commands/snapshot",
             "reference/commands/source",
+            "reference/commands/state-explain",
             "reference/commands/system",
             "reference/commands/test",
             "reference/commands/version",


### PR DESCRIPTION
Adds a new reference page for the `dbt state explain` (Fusion/dbt Core v2) and `dbt-state explain` (dbt Core v1 plugin) CLI command. This command is available when dbt State is enabled and lets users audit why dbt State made each decision after a run — whether a node was executed, skipped, or cloned.

**Changes:**
- New reference page: `/reference/commands/state-explain` — covers default output, verbose mode, and example output for both engine versions
- Updated `dbt-state-about.md` and `dbt-state-setup.md` to reference the new command
- Updated `views-rebuilt.md` FAQ — replaced the outdated experimental callout with updated diagnosis instructions and versioned code examples
- Added release note entry

Woohoo promoted from dbt-labs/docs-internal#2301

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-dbt-state-explain-public-dbt-labs.vercel.app/docs/dbt-versions/release-notes
- https://docs-getdbt-com-git-dbt-state-explain-public-dbt-labs.vercel.app/docs/deploy/dbt-state-about
- https://docs-getdbt-com-git-dbt-state-explain-public-dbt-labs.vercel.app/docs/deploy/dbt-state-setup
- https://docs-getdbt-com-git-dbt-state-explain-public-dbt-labs.vercel.app/faqs/State/views-rebuilt
- https://docs-getdbt-com-git-dbt-state-explain-public-dbt-labs.vercel.app/reference/commands/state-explain

<!-- end-vercel-deployment-preview -->