### PR TITLE
Style comments in code blocks that contain links

### DIFF
--- a/website/docs/reference/resource-properties/anchors.md
+++ b/website/docs/reference/resource-properties/anchors.md
@@ -1,5 +1,6 @@
 ---
 title: anchors
+description: "Use the anchors key to hold reusable YAML config fragments so they pass file validation."
 sidebar_label: "anchors"
 id: anchors
 ---

--- a/website/docs/reference/resource-properties/columns.md
+++ b/website/docs/reference/resource-properties/columns.md
@@ -1,4 +1,5 @@
 ---
+description: "Use the columns property to document and test individual columns on models, sources, seeds, and snapshots."
 resource_types: all
 datatype: test
 ---

--- a/website/docs/reference/resource-properties/config.md
+++ b/website/docs/reference/resource-properties/config.md
@@ -1,5 +1,6 @@
 ---
 title: "About config property"
+description: "Use the config property to set configs for a resource directly in its YAML file, instead of in dbt_project.yml."
 sidebar_label: "config"
 resource_types: [models, seeds, snapshots, tests, sources, metrics, exposures]
 datatype: "{dictionary}"

--- a/website/docs/reference/resource-properties/deprecation_date.md
+++ b/website/docs/reference/resource-properties/deprecation_date.md
@@ -1,4 +1,5 @@
 ---
+description: "Set a deprecation_date on a model to tell consumers when it will stop being supported."
 resource_types: [models]
 datatype: deprecation_date
 required: no

--- a/website/docs/reference/resource-properties/latest_version.md
+++ b/website/docs/reference/resource-properties/latest_version.md
@@ -1,4 +1,5 @@
 ---
+description: "Use latest_version to set which version of a versioned model unpinned ref() calls resolve to."
 resource_types: [models]
 datatype: latest_version
 required: no

--- a/website/docs/reference/resource-properties/versions.md
+++ b/website/docs/reference/resource-properties/versions.md
@@ -1,4 +1,5 @@
 ---
+description: "Use the versions property to define multiple versions of a model and how each one differs."
 resource_types: [models]
 datatype: list
 required: no

--- a/website/src/theme/CodeBlock/Content/inline-link.js
+++ b/website/src/theme/CodeBlock/Content/inline-link.js
@@ -47,12 +47,53 @@ function makeLink(text, url) {
   return makeToken(link);
 }
 
+/*
+ * Rebuilding a line as plain tokens loses Prism's highlighting, so find
+ * where a "#" comment starts and re-tag the rest of the line as a comment.
+ * "#{" is skipped: that's string interpolation, not a comment.
+ */
+function commentStart(string) {
+  const regex = /#(?!\{)/;
+  const match = string.match(regex);
+
+  return match ? match.index : -1;
+}
+
+/*
+ * Push a plain text segment, splitting off a trailing comment if one
+ * starts here. Returns true once the line is inside a comment, so
+ * following segments stay comment-colored.
+ */
+function pushText(tokens, string, inComment) {
+  if (!string) {
+    return inComment;
+  }
+
+  if (inComment) {
+    tokens.push(makeToken(string, ["comment"]));
+    return true;
+  }
+
+  const hashIndex = commentStart(string);
+  if (hashIndex === -1) {
+    tokens.push(makeToken(string));
+    return false;
+  }
+
+  if (hashIndex > 0) {
+    tokens.push(makeToken(string.slice(0, hashIndex)));
+  }
+  tokens.push(makeToken(string.slice(hashIndex), ["comment"]));
+  return true;
+}
+
 function replaceLinks(line) {
   /*
    * Loop until input line is empty!
    */
 
   var tokens = [];
+  var inComment = false;
   let lineBuffer = line;
   while (lineBuffer.length > 0) {
     let res = isMarkdownLink(lineBuffer);
@@ -61,17 +102,19 @@ function replaceLinks(line) {
       // if we've already found a link. Otherwise,
       // we just want to return null and escape below
       if (tokens.length > 0) {
-        tokens.push(makeToken(lineBuffer));
+        pushText(tokens, lineBuffer, inComment);
       }
       break;
     }
 
     var before = lineBuffer.slice(0, res.index);
     var after = lineBuffer.slice(res.index + res.original_length);
-    tokens.push(makeToken(before));
+
+    inComment = pushText(tokens, before, inComment);
     if (res.escape) {
-      tokens.push(makeToken(res.full));
+      tokens.push(makeToken(res.full, inComment ? ["comment"] : undefined));
     } else {
+      // links stay clickable even inside a comment
       tokens.push(makeLink(res.text, res.url));
     }
     lineBuffer = after;


### PR DESCRIPTION
## What changed

Comments in code blocks rendered as plain code whenever the same line contained a markdown link — for example in [Source properties](https://docs.getdbt.com/reference/source-properties), where `# moved under config in v1.10` sat next to a linked key.

Cause is in `website/src/theme/CodeBlock/Content/inline-link.js`. The `squashLinks` helper rebuilds any line containing a markdown link as plain `text` tokens, discarding Prism's tokens for that whole line — comments included. Lines without a link were never affected, which is why `# required` looked right and the linked lines didn't.

The fix re-tags the text after a `#` as a `comment` token when rebuilding the line, so it picks up the theme's comment styling.

Also adds page descriptions to six resource-properties reference pages: `columns`, `config`, `deprecation_date`, `latest_version`, `versions`, and `anchors`.

## Scope

Checked every code block in `docs/`, `snippets/`, and `blog/`:

- 54 lines gain comment styling (49 yml/yaml, 3 sql, 1 bash)
- 5 lines have a link inside a comment — the link stays clickable, surrounding text is gray
- `#{` is skipped so string interpolation isn't treated as a comment (`guides/zapier-ms-teams.md`)
- lines with no markdown link are untouched; Prism's tokens pass through as before

Keys and values on link-carrying lines are still plain text, unchanged from today — `squashLinks` has always discarded those tokens. This only recovers comments.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-update-fix-comments-dbt-labs.vercel.app/reference/resource-properties/anchors
- https://docs-getdbt-com-git-update-fix-comments-dbt-labs.vercel.app/reference/resource-properties/columns
- https://docs-getdbt-com-git-update-fix-comments-dbt-labs.vercel.app/reference/resource-properties/config
- https://docs-getdbt-com-git-update-fix-comments-dbt-labs.vercel.app/reference/resource-properties/deprecation_date
- https://docs-getdbt-com-git-update-fix-comments-dbt-labs.vercel.app/reference/resource-properties/latest_version
- https://docs-getdbt-com-git-update-fix-comments-dbt-labs.vercel.app/reference/resource-properties/versions

<!-- end-vercel-deployment-preview -->