### PR TITLE
[dbt State] compare_unrendered_code

### DIFF
--- a/website/docs/docs/dbt-versions/release-notes.md
+++ b/website/docs/docs/dbt-versions/release-notes.md
@@ -22,6 +22,7 @@ For <Constant name="fusion_engine" /> updates, refer to the [dbt-fusion changelo
 
 ## August 2026
 
+- **New**: [`compare_unrendered_code`](/reference/resource-configs/compare-unrendered-code) is a new dbt State config that checks the Jinja template for unrendered code changes. If dbt detects unrendered code changes, it then compares the rendered SQL. A rebuild only occurs when _both_ have changed. This prevents unnecessary rebuilds for nodes that use non-deterministic macros or environment variables.
 - **New:** When dbt State is enabled, you can run `dbt state explain` (<Constant name="core_v2" />) or `dbt-state explain` (<Constant name="core" /> plugin) in the CLI after a job finishes to see why dbt State made each decision and whether each node was built, reused, or cloned. For a detailed breakdown, run the command with `--verbose -s my_node_name` to see the table analysis, query analysis, and data freshness analysis for a specific node. For more information, refer to [`dbt state explain`](/reference/commands/state-explain).
 - **Enhancement:** New sessions open on the Wizard tab when available, and the <Constant name="studio_ide" /> remembers your last-used tab for each project so you can pick up where you left off.
 - **Enhancement:** A new `relationName` field on the `ModelAppliedStateNode` and `ModelAppliedStateNestedNode` GraphQL types exposes the fully-qualified, adapter-rendered relation name (for example, `"database"."schema"."model_name"`) from the last successful model build.

--- a/website/docs/faqs/State/model-change-calculation.md
+++ b/website/docs/faqs/State/model-change-calculation.md
@@ -6,3 +6,7 @@ id: model-change-calculation
 ---
 
 dbt State only considers substantial changes to a model. Because dbt State understands the entire lineage of your models, it can see through things like whitespace and aliases to determine whether a model is the same or different across environments.
+
+By default, dbt State compares rendered SQL to detect code changes. Any change to the rendered SQL &mdash; including from non-deterministic macros or environment variables &mdash; triggers a rebuild.
+
+You can enable [`compare_unrendered_code`](/reference/resource-configs/compare-unrendered-code) to also check the Jinja template (unrendered code). When enabled, a rebuild only occurs when both the template _and_ the rendered SQL have changed. Non-deterministic values (for example, `{{ env_var('AIRFLOW_RUN_ID') }}` or a macro that calls `uuid()`) don't trigger rebuilds as long as the template itself is unchanged, which helps avoid unnecessary warehouse compute costs.

--- a/website/docs/faqs/State/views-rebuilt.md
+++ b/website/docs/faqs/State/views-rebuilt.md
@@ -34,7 +34,7 @@ renamed as (
 select * from renamed
 ```
 
-dbt State reuses a model when its compiled SQL matches the stored hash. For views with `select *`, dbt State can't determine which columns the query selects without querying the upstream schema, so it can't confirm the SQL is unchanged. It always rebuilds these views to avoid errors &mdash; if the upstream table gains a column, querying the view can fail. When dbt State rebuilds a view, it also re-runs any tests defined on the model.
+dbt State reuses a model when its rendered SQL matches the stored hash. For views with `select *`, dbt State can't determine which columns the query selects without querying the upstream schema, so it can't confirm the SQL is unchanged. It always rebuilds these views to avoid errors &mdash; if the upstream table gains a column, querying the view can fail. When dbt State rebuilds a view, it also re-runs any tests defined on the model.
 
 :::tip
 To make this view eligible for reuse, remove the imported CTE and reference the source directly with explicit column names:
@@ -51,9 +51,21 @@ If you can't remove `select *`, you can exclude views from running with `--exclu
 
 ## Non-deterministic Jinja templating
 
-Some macros, such as `dbt_utils.get_relations_by_pattern` (an introspective macro) combined with `dbt_utils.union_relations`, can return relations in a different order on each run. That produces different compiled SQL even when your project logic hasn't changed. dbt State detects a new hash and rebuilds the model.
+Some macros and environment variables can cause unexpected rebuilds. For example, `dbt_utils.get_relations_by_pattern` (an introspective macro) combined with `dbt_utils.union_relations` can return relations in a different order on each run, producing different rendered SQL even when your project logic hasn't changed. Similarly, environment variables that change between runs produce different rendered SQL on every run:
 
-This pattern can affect any model type, not just views. If a base or staging model rebuilds on every run, all of its downstream models rebuild, too.
+```sql
+select '{{ env_var("AIRFLOW_RUN_ID") }}' as airflow_run_id, ...
+```
+
+Because the query result order or the environment variable's value changes, the rendered SQL differs from the stored hash on every run. dbt State treats this as a code change and rebuilds the model, even though the underlying project logic hasn't changed. This pattern can affect any model type, not just views; if a base or staging model rebuilds on every run, all of its downstream models rebuild, too.
+
+To avoid these unnecessary rebuilds, enable [`compare_unrendered_code`](/reference/resource-configs/compare-unrendered-code). When enabled, dbt State checks both the Jinja template and rendered SQL; non-deterministic values that don't change the template don't trigger a rebuild. For example:
+
+```sql
+{{ config(state={"compare_unrendered_code": true}) }}
+
+select '{{ env_var("AIRFLOW_RUN_ID") }}' as airflow_run_id, ...
+```
 
 ## Models with external sources on BigQuery
 

--- a/website/docs/reference/resource-configs/compare-unrendered-code.md
+++ b/website/docs/reference/resource-configs/compare-unrendered-code.md
@@ -1,0 +1,121 @@
+---
+title: compare_unrendered_code
+description: "Controls whether dbt State checks both the Jinja template (unrendered code) and rendered SQL when deciding whether a model has changed."
+id: "compare-unrendered-code"
+tags: ['dbt State']
+---
+
+# compare_unrendered_code
+
+<Tabs>
+<TabItem value="project" label="Project YAML file">
+
+<File name="dbt_project.yml">
+
+```yaml
+models:
+  [<resource-path>](/reference/resource-configs/resource-path):
+    [+](/reference/resource-configs/plus-prefix)state:
+      compare_unrendered_code: true | false
+```
+
+</File>
+</TabItem>
+
+<TabItem value="property" label="Properties YAML file">
+
+<File name="models/<filename>.yml">
+
+```yaml
+models:
+  - name: my_model
+    config:
+      state:
+        compare_unrendered_code: true | false
+```
+
+</File>
+</TabItem>
+
+<TabItem value="sql" label="SQL file config">
+
+<File name="models/<filename>.sql">
+
+```sql
+{{ config(
+    state={
+      "compare_unrendered_code": true | false
+    }
+) }}
+```
+
+</File>
+</TabItem>
+</Tabs>
+
+## Definition
+
+<SimpleTable>
+| Value | Behavior |
+|-------|----------|
+| `false` (default) | dbt State compares only rendered SQL. Non-deterministic macros or env vars that change the rendered SQL on each run may trigger unnecessary rebuilds. |
+| `true` | dbt State avoids unnecessary rebuilds by checking both the Jinja template and rendered SQL. A rebuild only occurs when both have changed. |
+</SimpleTable>
+
+By default, dbt State compares only rendered SQL and rebuilds when the output differs from the stored hash. How frequently that happens depends on how often the values change. For example:
+
+- `{{ invocation_id() }}` resolves to a new value on every run, so it always triggers a rebuild.
+- `{{ dbt_utils.get_column_values() }}` only changes if the underlying column values change or return in a different order, so it triggers rebuilds less predictably.
+- `{{ modules.datetime.datetime.now().month }}` only resolves to a new value once a month, so it triggers a rebuild on the next run after the month changes.
+
+Set `compare_unrendered_code: true` to avoid these unnecessary rebuilds. When enabled, dbt State also checks the unrendered Jinja template, and only rebuilds when both the unrendered code _and_ the rendered SQL have changed. This is useful for nodes with non-deterministic macros or environment variables (such as a macro that returns a UUID, or `{{ env_var('AIRFLOW_RUN_ID') }}`) that produce different rendered SQL on every run even when the template itself is unchanged.
+
+## Interaction with `evaluate_volatile_sql`
+
+When `compare_unrendered_code` is enabled, dbt State checks whether the unrendered Jinja template has changed. If the template is unchanged, dbt State skips SQL parsing entirely &mdash; volatile SQL functions are not evaluated and [`evaluate_volatile_sql`](/reference/resource-configs/evaluate-volatile-sql) has no effect. If the unrendered template has changed, dbt State proceeds to parse and compare the rendered SQL, and `evaluate_volatile_sql` applies.
+
+## Examples
+
+### Model with a non-deterministic environment variable
+
+A model with a non-deterministic environment variable is reused as long as neither the model's own Jinja template nor the source of any macros it calls has changed, even if the environment variable (for example, AIRFLOW_RUN_ID) resolves to a different value at runtime:
+
+<File name="models/fct_events.sql">
+
+```sql
+{{ config(state={"compare_unrendered_code": true}) }}
+
+select
+  event_id,
+  user_id,
+  event_type,
+  occurred_at,
+  '{{ env_var("AIRFLOW_RUN_ID") }}' as airflow_run_id
+from {{ ref('stg_events') }}
+```
+
+</File>
+
+### Model with dbt run metadata columns
+
+A model that records which dbt run produced each row using [`invocation_id()`](/reference/dbt-jinja-functions/invocation_id) or [`run_started_at`](/reference/dbt-jinja-functions/run_started_at) is reused as long as the template hasn't changed, even though those values resolve differently on every run:
+
+<File name="models/fct_orders.sql">
+
+```sql
+{{ config(state={"compare_unrendered_code": true}) }}
+
+select
+  *,
+  '{{ invocation_id() }}' as dbt_invocation_id,
+  '{{ run_started_at }}' as dbt_run_started_at
+from {{ ref('stg_orders') }}
+```
+
+</File>
+
+## Related docs
+
+- [About dbt State](/docs/deploy/dbt-state-about)
+- [dbt State configs](/reference/resource-configs/dbt-state-configs)
+- [Set up dbt State](/docs/deploy/dbt-state-setup)

--- a/website/docs/reference/resource-configs/dbt-state-configs.md
+++ b/website/docs/reference/resource-configs/dbt-state-configs.md
@@ -22,6 +22,7 @@ Use the following configs to control how dbt State makes these decisions.
 models:
   +state:
     lag_tolerance: <duration>
+    compare_unrendered_code: true | false
     require_fresh_data_from: any | all
     evaluate_volatile_sql: true | false
     pre_clone: never | if_missing | always
@@ -41,6 +42,7 @@ models:
     config:
       state:
         lag_tolerance: <duration>
+        compare_unrendered_code: true | false
         require_fresh_data_from: any | all
         evaluate_volatile_sql: true | false
         pre_clone: never | if_missing | always
@@ -58,6 +60,7 @@ models:
 {{ config(
     state={
         "lag_tolerance": "<duration>",
+        "compare_unrendered_code": true | false,
         "require_fresh_data_from": "any" | "all",
         "evaluate_volatile_sql": true | false,
         "pre_clone": "never" | "if_missing" | "always",
@@ -73,6 +76,7 @@ models:
 | Config | Default | Scope | Description |
 |--------|---------|-------|-------------|
 | [`lag_tolerance`](/reference/resource-configs/lag-tolerance) | `45m` | Node, folder, or project-level via model config | How much time must pass since the last upstream data change before a node is eligible for a rebuild. Acts as a compute-saving buffer that helps align builds with freshness SLAs. Applies to data freshness only; SQL changes always trigger a rebuild regardless of this setting. |
+| [`compare_unrendered_code`](/reference/resource-configs/compare-unrendered-code) | `false` | Node, folder, or project-level via model config | Controls whether dbt State checks both the Jinja template (unrendered code) and rendered SQL when detecting code changes. Useful for models with non-deterministic macros or environment variables that produce different rendered SQL on every run. |
 | [`require_fresh_data_from`](/reference/resource-configs/require-fresh-data-from) | `any` | Node, folder, or project-level via model config | Whether `any` or `all` direct parents need fresh data before a node is eligible for a rebuild. |
 | [`pre_clone`](/reference/resource-configs/pre-clone) | `if_missing` | Node, folder, or project-level via model config | Whether dbt State pre-populates incremental models and snapshots by cloning production before a run. |
 | [`execute_hooks_on_any_reuse`](/reference/resource-configs/execute-hooks-on-any-reuse) | `false` | Node, folder, or project-level via model config | Whether pre- and post-hooks run when a node is reused without rebuilding. |

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -1404,6 +1404,7 @@ const sidebarSettings = {
           items: [
             "reference/resource-configs/dbt-state-configs",
             "reference/resource-configs/lag-tolerance",
+            "reference/resource-configs/compare-unrendered-code",
             "reference/resource-configs/require-fresh-data-from",
             "reference/resource-configs/evaluate-volatile-sql",
             "reference/resource-configs/pre-clone",


### PR DESCRIPTION
Docs for the new `compare_unrendered_code` dbt State config, which prevents unnecessary rebuilds for nodes that use non-deterministic macros or environment variables.

Woohoo promoted from dbt-labs/docs-internal#2260