### PR TITLE
Remove dbt Core v1.12 Live CTA from Core upgrade guides

### DIFF
--- a/website/docs/docs/dbt-versions/core-upgrade/01-upgrading-to-v2.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/01-upgrading-to-v2.md
@@ -3,7 +3,6 @@ title: "Upgrading to v2"
 id: upgrading-to-v2
 description: New features and changes in v2
 displayed_sidebar: "docs"
-cta: dbt_core_v1_12_live
 availability:
   engine: v2
   access: free

--- a/website/docs/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.12.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/03-upgrading-to-v1.12.md
@@ -3,7 +3,6 @@ title: "Upgrading to v1.12"
 id: upgrading-to-v1.12
 description: New features and changes in dbt Core v1.12
 displayed_sidebar: "docs"
-cta: dbt_core_v1_12_live
 availability:
   engine: v1
   access: free

--- a/website/docs/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/04-upgrading-to-v1.11.md
@@ -3,7 +3,6 @@ title: "Upgrading to v1.11"
 id: upgrading-to-v1.11
 description: New features and changes in dbt Core v1.11
 displayed_sidebar: "docs"
-cta: dbt_core_v1_12_live
 availability:
   engine: v1
   access: free

--- a/website/docs/docs/dbt-versions/core-upgrade/05-upgrading-to-v1.10.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/05-upgrading-to-v1.10.md
@@ -3,7 +3,6 @@ title: "Upgrading to v1.10"
 id: upgrading-to-v1.10
 description: New features and changes in dbt Core v1.10
 displayed_sidebar: "docs"
-cta: dbt_core_v1_12_live
 availability:
   engine: v1
   access: free

--- a/website/docs/docs/dbt-versions/core-upgrade/06-upgrading-to-v1.9.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/06-upgrading-to-v1.9.md
@@ -3,7 +3,6 @@ title: "Upgrading to v1.9"
 id: upgrading-to-v1.9
 description: New features and changes in dbt Core v1.9
 displayed_sidebar: "docs"
-cta: dbt_core_v1_12_live
 availability:
   engine: v1
   access: free

--- a/website/docs/docs/dbt-versions/core-upgrade/07-upgrading-to-v1.8.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/07-upgrading-to-v1.8.md
@@ -3,7 +3,6 @@ title: "Upgrading to v1.8"
 id: upgrading-to-v1.8
 description: New features and changes in dbt Core v1.8
 displayed_sidebar: "docs"
-cta: dbt_core_v1_12_live
 availability:
   engine: v1
   access: free

--- a/website/docs/docs/dbt-versions/core-upgrade/08-upgrading-to-v1.7.md
+++ b/website/docs/docs/dbt-versions/core-upgrade/08-upgrading-to-v1.7.md
@@ -3,7 +3,6 @@ title: "Upgrading to v1.7"
 id: upgrading-to-v1.7
 description: New features and changes in dbt Core v1.7
 displayed_sidebar: "docs"
-cta: dbt_core_v1_12_live
 availability:
   engine: v1
   access: free


### PR DESCRIPTION
## What are you changing in this pull request and why?

Jira: [GTM-1034676](https://fivetran.atlassian.net/browse/GTM-1034676)

The "dbt Core v1.12 Live" webinar has wrapped (global sessions August 26 and 27, 2026), so this takes the side CTA back down. Follow-up to [GTM-1031617](https://fivetran.atlassian.net/browse/GTM-1031617), which added it.

Removes the `cta: dbt_core_v1_12_live` frontmatter line from the seven dbt Core upgrade guides that carried it.

**What reviewers should look for:** the right-hand table-of-contents sidebar on each page below should no longer show the "dbt Core v1.12 Live" card. Nothing else on the pages should change. The sidebar CTA is rendered from `frontMatter.cta` in `website/src/theme/DocItem/Layout/index.js`, so dropping the frontmatter key is the whole change — no component or styling changes needed.

**Note on `ctas.yml`:** the `dbt_core_v1_12_live` entry is intentionally left in place in `website/blog/ctas.yml`. It's now unreferenced, which matches how earlier expired CTAs (`fast_track_dbt_workshop`, `fusion_webinar`, `dbt_state_july_2026_webinar`, etc.) are handled, and respects the file's "name property should not be changed once set" note. Happy to delete the entry instead if the team would rather prune retired CTAs.

## Preview links

One per affected page — the CTA card should be absent from the TOC sidebar on each:

- [Upgrading to v2](https://docs-getdbt-com-git-gtm-1034676-remove-core-v11-6790f2-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/upgrading-to-v2?version=2.0)
- [Upgrading to v1.12](https://docs-getdbt-com-git-gtm-1034676-remove-core-v11-6790f2-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/upgrading-to-v1.12?version=2.0)
- [Upgrading to v1.11](https://docs-getdbt-com-git-gtm-1034676-remove-core-v11-6790f2-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/upgrading-to-v1.11)
- [Upgrading to v1.10](https://docs-getdbt-com-git-gtm-1034676-remove-core-v11-6790f2-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/upgrading-to-v1.10)
- [Upgrading to v1.9](https://docs-getdbt-com-git-gtm-1034676-remove-core-v11-6790f2-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/upgrading-to-v1.9)
- [Upgrading to v1.8](https://docs-getdbt-com-git-gtm-1034676-remove-core-v11-6790f2-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/upgrading-to-v1.8)
- [Upgrading to v1.7](https://docs-getdbt-com-git-gtm-1034676-remove-core-v11-6790f2-dbt-labs.vercel.app/docs/dbt-versions/core-upgrade/upgrading-to-v1.7)

## Checklist
- [x] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [x] Frontmatter-only change; no versioning rules apply.
- [x] No release note needed — this removes a time-boxed marketing CTA, not product content.
- [x] Self-reviewed the diff; `npm run lint` passed via the pre-commit hook.
- [x] Verified on a local dev server that the generated `frontMatter.cta` is now empty for every page under `core-upgrade/` (and confirmed the check is sensitive — re-adding the key made it reappear).
- [x] Visual QA: eyeball the preview links above to confirm the CTA card is gone from the TOC sidebar. The sidebar CTA is client-rendered, so it can't be confirmed by inspecting the served HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
