### PR TITLE
Add AWS + Iceberg page and update DuckDB Iceberg docs

### DIFF
--- a/website/docs/docs/build/iceberg/adapters/aws-iceberg-support.md
+++ b/website/docs/docs/build/iceberg/adapters/aws-iceberg-support.md
@@ -1,0 +1,209 @@
+---
+title: "Amazon Web Services and Apache Iceberg"
+id: aws-iceberg-support
+sidebar_label: "AWS Iceberg support"
+description: Understand dbt support for Apache Iceberg on AWS, including the AWS Glue Data Catalog, Amazon Athena, and Amazon S3 Tables.
+---
+
+dbt materializes Iceberg tables on AWS through the [AWS Glue Data Catalog](#aws-glue-data-catalog), the catalog that AWS analytics engines share. There are two ways to configure it:
+
+- **Simplest:** The model config `table_type = 'iceberg'` instructs dbt to materialize this model as an Iceberg table in the AWS Glue Data Catalog through Amazon Athena.
+- **Extensible:** Define an Iceberg catalog in `catalogs.yml` and configure this model with `catalog_name`. This is required to target [Amazon S3 Tables](#amazon-s3-tables).
+
+dbt supports creating Iceberg tables for two Athena materializations:
+
+- [Table](/docs/build/materializations#table)
+- [Incremental](/docs/build/materializations#incremental), with the `merge` strategy
+
+## AWS Glue Data Catalog
+
+On AWS, the [AWS Glue Data Catalog](https://docs.aws.amazon.com/athena/latest/ug/glue-athena.html) is the metadata layer that registers Iceberg tables. It is the shared source of truth that lets one engine write a table and another read it: Amazon Athena, Amazon Redshift, Amazon EMR, and Apache Spark all resolve Iceberg tables through Glue. dbt drives Glue through the engine's adapter &mdash; today that is [dbt-athena](/docs/core/connect-data-platform/athena-setup).
+
+Amazon S3 Tables extends this model with a managed Iceberg catalog that owns its own storage, surfaced to Glue through a federated catalog. Both paths register governed Iceberg tables that any Glue-connected engine can read.
+
+## Amazon Athena and Iceberg
+
+Athena queries Iceberg tables registered in the AWS Glue Data Catalog. Iceberg tables require [Athena engine version 3](https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html) and, outside of Amazon S3 Tables, a unique table location.
+
+To connect dbt to Athena, define a dbt-athena target in `profiles.yml`:
+
+<File name='profiles.yml'>
+
+```yaml
+my_profile:
+  target: dev
+  outputs:
+    dev:
+      type: athena
+      s3_staging_dir: s3://my-athena-results-bucket/staging/
+      region_name: <region>
+      database: awsdatacatalog
+      schema: my_schema
+      threads: 4
+```
+
+</File>
+
+For the full set of connection options, see the [dbt-athena setup page](/docs/core/connect-data-platform/athena-setup).
+
+Without a `catalogs.yml`, set `table_type='iceberg'` directly on the model:
+
+<File name="models/my_iceberg_model.sql">
+
+```sql
+{{
+    config(
+        materialized = 'table',
+        table_type = 'iceberg',
+        format = 'parquet'
+    )
+}}
+
+select * from {{ ref('jaffle_shop_customers') }}
+```
+
+</File>
+
+## Amazon S3 Tables
+
+[Amazon S3 Tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables.html) is AWS's managed Apache Iceberg storage. S3 Tables owns its own storage location and Iceberg snapshots, so it isn't addressed the same way as a regular Glue-backed Iceberg table &mdash; it needs the dedicated `type: s3_tables` catalog integration.
+
+:::info Requires a recent dbt-athena
+S3 Tables support was added in [`dbt-labs/dbt-adapters#2047`](https://github.com/dbt-labs/dbt-adapters/pull/2047), merged 2026-07-17. As of this writing it is not yet in an official stable `dbt-athena` release on PyPI (latest stable is `1.11.0`, dated one day before the merge). It is already available on dbt Cloud. To use it locally or self-hosted before the next stable release, install directly from GitHub:
+
+```shell
+pip install "git+https://github.com/dbt-labs/dbt-adapters.git@main#subdirectory=dbt-athena"
+```
+:::
+
+`catalogs.yml` support requires the `use_catalogs_v2` behavior flag:
+
+<File name='dbt_project.yml'>
+
+```yaml
+flags:
+  use_catalogs_v2: true
+```
+
+</File>
+
+### Prerequisite: enable the S3 Tables and Glue Data Catalog integration
+
+Athena reaches an S3 Tables bucket through a federated Glue catalog named `s3tablescatalog`, which mounts your S3 Tables buckets as child catalogs. Enable it once per account/Region, either from the Amazon S3 console (select **Enable integration** when creating a table bucket) or with the AWS CLI:
+
+```shell
+aws glue create-catalog \
+  --name "s3tablescatalog" \
+  --catalog-input '{
+    "Description": "Federated catalog for S3 Tables",
+    "FederatedCatalog": {
+      "Identifier": "arn:aws:s3tables:<region>:<account-id>:bucket/*",
+      "ConnectionName": "aws:s3tables"
+    },
+    "CreateDatabaseDefaultPermissions": [{
+      "Principal": {"DataLakePrincipalIdentifier": "IAM_ALLOWED_PRINCIPALS"},
+      "Permissions": ["ALL"]
+    }],
+    "CreateTableDefaultPermissions": [{
+      "Principal": {"DataLakePrincipalIdentifier": "IAM_ALLOWED_PRINCIPALS"},
+      "Permissions": ["ALL"]
+    }]
+  }'
+```
+
+The `IAM_ALLOWED_PRINCIPALS` default shown above puts the catalog in IAM-only mode: Athena's access to the S3 Tables bucket is governed by the query role's IAM permissions, with no AWS Lake Formation setup required. Lake Formation is optional, for teams that want fine-grained or centrally managed grants. See [Enabling S3 Tables integration with the Data Catalog](https://docs.aws.amazon.com/glue/latest/dg/enable-s3-tables-catalog-integration.html) for both options.
+
+### Configure catalog integration for S3 Tables
+
+1. Create a `catalogs.yml` at the top level of your dbt project:
+
+<File name='catalogs.yml'>
+
+```yaml
+catalogs:
+  - name: s3_tables_catalog
+    type: s3_tables
+    table_format: iceberg
+    config:
+      athena:
+        catalog_database: s3tablescatalog/<your-table-bucket-name>
+        file_format: parquet
+```
+
+</File>
+
+   `catalog_database` is the federated catalog name for your S3 Tables bucket &mdash; the same name Athena uses to address it. It routes the model's `database`; the model's `schema` is the S3 Tables namespace. Omitting `catalog_database` falls back to the profile's `database`.
+
+2. Add the `catalog_name` config parameter in either a config block (inside the `.sql` model file), properties YAML file (model folder), or your project YAML file (`dbt_project.yml`):
+
+<File name='models/my_s3_tables_model.sql'>
+
+```sql
+{{
+    config(
+        materialized = 'table',
+        catalog_name = 's3_tables_catalog',
+        schema = 'my_namespace'
+    )
+}}
+
+select * from {{ ref('jaffle_shop_customers') }}
+```
+
+</File>
+
+3. Execute the dbt model with `dbt run -s my_s3_tables_model`.
+
+For an incremental model using the `merge` strategy:
+
+<File name='models/my_incremental_s3_tables_model.sql'>
+
+```sql
+{{
+    config(
+        materialized = 'incremental',
+        incremental_strategy = 'merge',
+        unique_key = 'id',
+        catalog_name = 's3_tables_catalog',
+        schema = 'my_namespace'
+    )
+}}
+
+select * from {{ ref('my_s3_tables_model') }}
+```
+
+</File>
+
+On the first run, when the target table does not yet exist, the incremental model creates it with a standard `CREATE TABLE AS` (the same drop-and-recreate-aware path the `table` materialization uses), then switches to `merge` on subsequent runs. No `--full-refresh` is needed to bootstrap the table.
+
+### How dbt writes to S3 Tables
+
+The `s3_tables` catalog integration accounts for storage and DDL differences between S3 Tables and a standard Glue-backed Iceberg table:
+
+- **No `LOCATION`** is set on `CREATE TABLE AS` &mdash; S3 Tables manages its own storage and rejects a supplied location.
+- **Table replacement uses drop-and-recreate**, routed through the Glue Data Catalog's metadata delete (not a SQL `DROP TABLE`, and not a direct S3 delete) &mdash; S3 Tables does not support `ALTER TABLE ... RENAME`, which the standard Glue `table` materialization otherwise uses for a near-zero-downtime swap.
+- Glue reports an S3 Tables table's `TableType` as `customer` (or `aws` for service-managed tables), neither of which is a standard Glue table type. dbt classifies these correctly as Iceberg tables.
+
+### Known limitation: incremental `--full-refresh`
+
+As of `dbt-athena` including `dbt-adapters#2047`, a normal incremental `merge` run works correctly, including repeated runs. However, running an incremental model with `--full-refresh` currently fails:
+
+```
+An error occurred (InvalidRequestException) when calling the StartQueryExecution
+operation: Unsupported DDL query for S3 table buckets
+```
+
+This happens because the incremental materialization's full-refresh path still swaps tables with `ALTER TABLE ... RENAME TO ...__bkp`, which S3 Tables does not support. The `table` materialization's drop-and-recreate fix does not currently extend to this path. Until this is addressed upstream, avoid `--full-refresh` on incremental S3 Tables models; instead, drop the table via the S3 Tables API/console and re-run, or rebuild it as a `table` materialization.
+
+## AWS-specific configs for Iceberg catalogs
+
+Supply these configs nested under `config.athena` in a `catalogs.yml` catalog entry:
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `catalog_database` | Optional | Federated Glue catalog name for the target bucket, for example `s3tablescatalog/<bucket-name>`. Routes the model's `database`. Falls back to the profile's `database` if omitted. |
+| `file_format` | Optional | File format for written data files. Defaults to `parquet`. |
+
+## Other AWS engines
+
+Support for additional AWS engines will be documented here as their dbt adapters add first-class Iceberg catalog integration. Today, engines such as dbt-spark (on Amazon EMR), dbt-trino, and dbt-redshift can read and write Glue-registered Iceberg tables by configuring the engine's own Iceberg catalog against the AWS Glue Data Catalog or the S3 Tables Iceberg REST endpoint, but they do not yet expose a native AWS `catalog_type` in `catalogs.yml`.

--- a/website/docs/docs/build/iceberg/adapters/duckdb-iceberg-support.md
+++ b/website/docs/docs/build/iceberg/adapters/duckdb-iceberg-support.md
@@ -5,11 +5,11 @@ sidebar_label: "DuckDB Iceberg support"
 description: Understand DuckDB support for Apache Iceberg.
 ---
 
-# DuckDB and Apache Iceberg <Lifecycle status="beta" />
+<Lifecycle status="beta" />
 
-:::info <Constant name="fusion" /> only
+:::info Fusion only
 
-DuckDB support for `catalogs.yml` requires the [<Constant name="fusion_engine" />](/docs/fusion/about-fusion) (v2) with the `use_catalogs_v2` behavior flag enabled. It isn't available in the legacy Python `dbt-duckdb` adapter for dbt Core v1.
+DuckDB support for `catalogs.yml` requires the [dbt Fusion engine](/docs/fusion/about-fusion) (v2) with the `use_catalogs_v2` behavior flag enabled. It isn't available in the legacy Python `dbt-duckdb` adapter for dbt Core v1.
 
 <File name='dbt_project.yml'>
 
@@ -85,6 +85,102 @@ catalogs:
 </File>
 
 `endpoint` and `endpoint_type` are mutually exclusive.
+
+:::caution Writing to S3 Tables: use the explicit `endpoint` form, not `endpoint_type`
+
+The `endpoint_type: S3_TABLES` shortcut shown above works for *reading* from S3 Tables, but as of the current Fusion preview builds, it incorrectly defaults the REST catalog authentication to OAuth2 instead of SigV4 when **writing**. This surfaces as either:
+
+```
+Invalid Configuration Error: AUTHORIZATION_TYPE is 'oauth2', yet no 'secret' was provided...
+```
+or, if a secret is attached to the catalog directly:
+```
+InvalidArguments: HTTP Error: Failed to retrieve OAuth2 token from  (sqlstate: ...)
+```
+
+S3 Tables authenticates with SigV4, not OAuth2. Until this is fixed, use the explicit `endpoint` + `authorization_type: SIGV4` form for any S3 Tables catalog you plan to write to. See [Amazon S3 Tables (write path)](#amazon-s3-tables-write-path) below for the full, verified configuration.
+:::
+
+## Amazon S3 Tables (write path)
+
+To materialize Iceberg models into an S3 Tables bucket, attach it as an `iceberg_rest` catalog using the explicit `endpoint` form together with SigV4 authentication, and set the S3 Tables write-compatibility options:
+
+<File name='catalogs.yml'>
+
+```yaml
+catalogs:
+  - name: s3_tables_catalog
+    type: iceberg_rest
+    table_format: iceberg
+    config:
+      duckdb:
+        endpoint: "https://s3tables.<region>.amazonaws.com/iceberg"
+        warehouse: "arn:aws:s3tables:<region>:<account-id>:bucket/<bucket-name>"
+        authorization_type: SIGV4
+        secret: s3_tables_secret
+        default_schema: <namespace>
+        stage_create_tables: false        # S3 Tables rejects staged CREATE TABLE AS SELECT
+        disable_multi_table_commit: true  # S3 Tables has no multi-table transaction commit endpoint
+        purge_requested: true             # S3 Tables only allows DROP TABLE with purge enabled
+```
+
+</File>
+
+`secret` references an `s3` credential-chain secret defined in `profiles.yml` (see [Secrets](#secrets) below) &mdash; this supplies the SigV4 credentials, not an OAuth2 token.
+
+<File name='profiles.yml'>
+
+```yaml
+my_profile:
+  target: dev
+  outputs:
+    dev:
+      type: duckdb
+      path: ':memory:'
+      extensions:
+        - iceberg
+        - aws
+        - httpfs
+      secrets:
+        - type: s3
+          name: s3_tables_secret
+          provider: credential_chain
+          region: <region>
+```
+
+</File>
+
+<File name='models/my_s3_tables_model.sql'>
+
+```sql
+{{
+    config(
+        materialized = 'table',
+        catalog_name = 's3_tables_catalog',
+        schema = '<namespace>'
+    )
+}}
+
+select * from {{ ref('jaffle_shop_customers') }}
+```
+
+</File>
+
+Because DuckDB's default schema is `main`, dbt's default schema-naming logic concatenates it with your model's custom schema (for example, `main_my_namespace`), which won't match an existing S3 Tables namespace. Add a project-level override so the schema resolves to your namespace exactly:
+
+<File name='macros/generate_schema_name.sql'>
+
+```sql
+{% macro generate_schema_name(custom_schema_name, node) -%}
+    {%- if custom_schema_name is none -%}
+        {{ target.schema }}
+    {%- else -%}
+        {{ custom_schema_name | trim }}
+    {%- endif -%}
+{%- endmacro %}
+```
+
+</File>
 
 ## Cross-platform Mesh: reading catalogs managed by other platforms
 
@@ -211,6 +307,8 @@ my_profile:
 
 </File>
 
+For Amazon S3 Tables specifically, use a `type: s3` / `provider: credential_chain` secret instead (SigV4, not OAuth2/token-based) &mdash; see [Amazon S3 Tables (write path)](#amazon-s3-tables-write-path) above.
+
 ## DuckDB-specific configs for Iceberg catalogs
 
 You can supply these configs, nested under `config.duckdb`, for `horizon`, `unity`, and `iceberg_rest` catalogs:
@@ -218,22 +316,22 @@ You can supply these configs, nested under `config.duckdb`, for `horizon`, `unit
 | Field | Required | Description |
 | --- | --- | --- |
 | `endpoint` | One of `endpoint`/`endpoint_type` | Full Iceberg REST catalog URL. |
-| `endpoint_type` | One of `endpoint`/`endpoint_type` | `GLUE` or `S3_TABLES`, for well-known AWS-managed endpoints. |
-| `warehouse` | Required for `horizon`; required when `endpoint_type` is `S3_TABLES` | Warehouse identifier passed as the `ATTACH` source. |
+| `endpoint_type` | One of `endpoint`/`endpoint_type` | `GLUE` or `S3_TABLES`, for well-known AWS-managed endpoints. For writing to S3 Tables, prefer the explicit `endpoint` form (see caution above). |
+| `warehouse` | Required for `horizon`; required for any Amazon S3 Tables catalog (both the `endpoint_type: S3_TABLES` and the explicit `endpoint` write path) | Warehouse identifier passed as the `ATTACH` source. |
 | `secret` | Optional | Name of a DuckDB secret from `profiles.yml` to use for authentication. |
 | `attach_as` | Optional | Overrides the DuckDB attach alias. Defaults to the catalog's `name`. |
 | `default_region` | Optional | AWS region, when applicable. |
 | `default_schema` | Optional | Default schema/namespace within the catalog. |
 | `max_table_staleness` | Optional | How long DuckDB may serve cached metadata before refreshing. |
-| `authorization_type` | Optional | `OAUTH2`, `SIGV4`, or `NONE`. Can't be combined with `endpoint_type`. |
+| `authorization_type` | Optional | `OAUTH2`, `SIGV4`, or `NONE`. Can't be combined with `endpoint_type`. Required as `SIGV4` when writing to S3 Tables. |
 | `access_delegation_mode` | Optional | `VENDED_CREDENTIALS` or `NONE`. |
 | `read_only` | Optional | Attach the catalog read-only. Defaults to `false` (read-write). |
 | `support_nested_namespaces` | Optional | Whether the catalog supports nested namespaces. |
-| `stage_create_tables` | Optional | Write-compat: stage `CREATE TABLE AS SELECT` writes. Requires DuckDB 1.5.4+. |
-| `disable_multi_table_commit` | Optional | Write-compat: disable multi-table commits. Requires DuckDB 1.5.4+. |
+| `stage_create_tables` | Optional | Write-compat: stage `CREATE TABLE AS SELECT` writes. Requires DuckDB 1.5.4+. Set to `false` for Amazon S3 Tables. |
+| `disable_multi_table_commit` | Optional | Write-compat: disable multi-table commits. Requires DuckDB 1.5.4+. Set to `true` for Amazon S3 Tables. |
 | `skip_create_table_metadata_updates` | Optional | Write-compat: skip metadata updates on `CREATE TABLE`. Requires DuckDB 1.5.4+. |
 | `remove_files_on_delete` | Optional | Write-compat: remove underlying data files when a table is dropped. Requires DuckDB 1.5.4+. |
-| `purge_requested` | Optional | Purge underlying files when supported by the catalog. |
+| `purge_requested` | Optional | Purge underlying files when supported by the catalog. Set to `true` for Amazon S3 Tables, which only allows `DROP TABLE` with purge enabled. |
 | `encode_entire_prefix` | Optional | Percent-encode the entire object key prefix. |
 
 For `ducklake` catalogs, `config.duckdb` accepts:

--- a/website/docs/docs/build/iceberg/adapters/duckdb-iceberg-support.md
+++ b/website/docs/docs/build/iceberg/adapters/duckdb-iceberg-support.md
@@ -9,7 +9,7 @@ description: Understand DuckDB support for Apache Iceberg.
 
 :::info <Constant name="Fusion" /> only
 
-DuckDB support for `catalogs.yml` requires the [dbt Fusion engine](/docs/fusion/about-fusion) (v2) with the `use_catalogs_v2` behavior flag enabled. It isn't available in the legacy Python `dbt-duckdb` adapter for dbt Core v1.
+DuckDB support for `catalogs.yml` requires the [<Constant name="fusion_engine" />](/docs/fusion/about-fusion) (v2) with the `use_catalogs_v2` behavior flag enabled. It isn't available in the legacy Python `dbt-duckdb` adapter for dbt Core v1.
 
 <File name='dbt_project.yml'>
 

--- a/website/docs/docs/build/iceberg/adapters/duckdb-iceberg-support.md
+++ b/website/docs/docs/build/iceberg/adapters/duckdb-iceberg-support.md
@@ -5,9 +5,9 @@ sidebar_label: "DuckDB Iceberg support"
 description: Understand DuckDB support for Apache Iceberg.
 ---
 
-<Lifecycle status="beta" />
+# DuckDB and Apache Iceberg <Lifecycle status="beta" />
 
-:::info Fusion only
+:::info <Constant name="Fusion" /> only
 
 DuckDB support for `catalogs.yml` requires the [dbt Fusion engine](/docs/fusion/about-fusion) (v2) with the `use_catalogs_v2` behavior flag enabled. It isn't available in the legacy Python `dbt-duckdb` adapter for dbt Core v1.
 

--- a/website/docs/docs/build/iceberg/apache-iceberg-support.md
+++ b/website/docs/docs/build/iceberg/apache-iceberg-support.md
@@ -55,4 +55,10 @@ To the extent possible, dbt tries to abstract away the complexity of table forma
     link="/docs/build/iceberg/adapters/duckdb-iceberg-support"
     icon="duckdb-seeklogo"/>
 
+<Card
+    title="AWS + Iceberg"
+    body="AWS Iceberg configurations, including Amazon S3 Tables"
+    link="/docs/build/iceberg/adapters/aws-iceberg-support"
+    icon="aws"/>
+
 </div>


### PR DESCRIPTION
## What are you changing in this pull request and why?

Describe your changes and why you're making them. If related to an open issue or a pull request on dbt Core or another repository, then link to them here! 
This PR adds first-class documentation for Apache Iceberg on AWS and corrects the existing DuckDB Iceberg page, based on behavior verified against a live AWS account with dbt-athena (dbt Cloud and a local dev-build install).

. New page: 
aws-iceberg-support.md
 ("AWS + Iceberg")

There is no AWS Iceberg page today. Unlike the other Iceberg adapter pages (Snowflake, BigQuery, Databricks, DuckDB), where the adapter is both the engine and the catalog, on AWS the catalog (AWS Glue Data Catalog / Amazon S3 Tables) is decoupled from the engine (Athena, Spark, Trino, Redshift). So this is a platform-level "AWS + Iceberg" page, not an engine-named "Athena" page, keeping it symmetrical with the other vendor tiles. It follows the Snowflake page's Simplest/Extensible structure:

AWS Glue Data Catalog — the shared metadata layer every AWS engine resolves through.
Amazon Athena and Iceberg — the Simplest path (table_type='iceberg'), including a profiles.yml connection example.
Amazon S3 Tables — the Extensible path (catalogs.yml, type: s3_tables): the Glue federated-catalog prerequisite, how dbt writes to S3 Tables (no LOCATION, drop-and-recreate, TableType handling), the incremental first-run behavior, and a known limitation where incremental --full-refresh fails because of an unsupported ALTER TABLE ... RENAME.
AWS-specific configs — a config.athena reference table mirroring the Snowflake page.
Other AWS engines — a forward-looking note for Spark/EMR, Trino, and Redshift.
2. Revised page: 
duckdb-iceberg-support.md

Corrections and additions verified in the same project:

Documents that the endpoint_type: S3_TABLES shortcut defaults REST auth to OAuth2 instead of SigV4 when writing, with the explicit endpoint + authorization_type: SIGV4 workaround.
Adds the three S3 Tables write-compatibility flags (stage_create_tables, disable_multi_table_commit, purge_requested) and a generate_schema_name note for the main_<namespace> concatenation.
Clarifies that warehouse is effectively required for any S3 Tables catalog (both the endpoint_type and explicit-endpoint forms).
Normalizes the page title to rely on frontmatter (removing the duplicate H1) while keeping the <Lifecycle status="beta" /> badge.
3. Index tile: 
apache-iceberg-support.md

Adds an "AWS + Iceberg" <Card> linking to the new page, alongside the existing Snowflake/BigQuery/Databricks/DuckDB tiles.

Note for reviewers — a few items need a maintainer's confirmation before merge:

(1) Icon slug: the new tile uses icon="aws" as a placeholder; please confirm the correct slug in dbt's icon set.
(2) dbt-athena version banner: as of 2026-08-26 the fix (#2047, merged 2026-07-17) is not yet in a stable PyPI release (latest is 1.11.0), so the page documents a GitHub install. If a newer stable release is out at merge time, this can be simplified to a standard version requirement.
(3) Can we include the S3 Table support is a part of release notes (PR #2047 and this)?


To learn more about the writing conventions used in the dbt Labs docs, see the [Content style guide](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md).


## Checklist
- [X] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date

- [X] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->

ADDING OR REMOVING PAGES (if so, uncomment):
- [] Add/remove page in `website/sidebars.js`
- [X] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages

