### PR TITLE
docs(databricks): add missing incremental_predicates to delete+insert example

### DIFF
--- a/website/docs/reference/resource-configs/databricks-configs.md
+++ b/website/docs/reference/resource-configs/databricks-configs.md
@@ -678,7 +678,8 @@ You can optionally use `incremental_predicates` to further filter which records 
     materialized='incremental',
     file_format='delta',
     incremental_strategy='delete+insert',
-    unique_key='user_id'
+    unique_key='user_id',
+    incremental_predicates='user_id >= 10000' # Never delete/insert users with ids < 10000
 ) }}
 
 with new_events as (
@@ -728,7 +729,7 @@ create temporary view delete_insert_incremental__dbt_tmp as
 insert into table analytics.delete_insert_incremental as target
 replace on (target.user_id <=> temp.user_id)
 (select `user_id`, `last_seen`
-   from delete_insert_incremental__dbt_tmp where date_day >= date_add(current_date, -1)) as temp
+   from delete_insert_incremental__dbt_tmp where user_id >= 10000) as temp
 ```
 
 </File>
@@ -761,13 +762,13 @@ create temporary view delete_insert_incremental__dbt_tmp as
 -- Step 1: Delete matching rows
 delete from analytics.delete_insert_incremental
 where analytics.delete_insert_incremental.user_id IN (SELECT user_id FROM delete_insert_incremental__dbt_tmp)
-  and date_day >= date_add(current_date, -1);
+  and user_id >= 10000;
 
 -- Step 2: Insert new rows
 insert into analytics.delete_insert_incremental by name
 select `user_id`, `last_seen`
 from delete_insert_incremental__dbt_tmp
-where date_day >= date_add(current_date, -1)
+where user_id >= 10000
 ```
 
 </File>


### PR DESCRIPTION
## Summary
- Fixes the inconsistent `delete+insert` docs on Databricks configs: the source example now includes `incremental_predicates`, matching the prose and the generated run SQL.
- Aligns the example with the existing `replace_where` pattern (`user_id >= 10000`), so the run tabs no longer reuse the model's `is_incremental()` `date_day` filter as if it were an `incremental_predicates` clause (that column is not in the temp view).
- Resolves [databricks/dbt-databricks#1652](https://github.com/databricks/dbt-databricks/issues/1652).

## Test plan
- [ ] Preview the Databricks configs page → **The `delete+insert` strategy** section
- [ ] Confirm Source / Run (DBR 17.1+) / Run (DBR < 17.1) tabs all show the same `incremental_predicates` (`user_id >= 10000`)
- [ ] Confirm the `is_incremental()` `date_day` filter still appears only in the model query / temp view, not as the insert/delete predicate