### PR TITLE
Pin internal actions to floating major tags (IS-6458)

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Get changed files
         id: changed-files
-        uses: dbt-labs/internal-actions/changed-files@6ff66921e5028a073bdc567410d363b1b78e3f59  # dbt-labs/internal-actions/changed-files@changed-files-v1
+        uses: dbt-labs/internal-actions/changed-files@changed-files-v1
         with:
           files: |
             website/**/*.md


### PR DESCRIPTION
Swaps 1 SHA-pinned `dbt-labs/internal-actions` refs to their floating major tags. Policy is major tag for internal actions, full SHA for external ones ([README](https://github.com/dbt-labs/internal-actions#pinning-policy)). Each ref already resolved to the major it's pinned at, so no behaviour change. IS-6458.

- `changed-files-v1`