### PR TITLE
Add Docs for Supporting 4-part Lakehouse Runtime Catalog Tables in BQ

### DIFF
--- a/website/docs/docs/build/iceberg/adapters/bigquery-iceberg-support.md
+++ b/website/docs/docs/build/iceberg/adapters/bigquery-iceberg-support.md
@@ -32,8 +32,9 @@ Supply and nest these additional configurations, unique to BigQuery, under `conf
 
 | Field | Type | Required | Description | Note |
 | ----- | ---- | -------- | ----------- | ---- |
-| `file_format` | String | Yes | The file format for the Iceberg table. | `parquet` is the only accepted value. |
-| `external_volume` | String | Yes | The Cloud Storage bucket where Iceberg table data is written. | For example, `gs://BUCKET_NAME`. |
+| `file_format` | String | Yes, except for LRC catalogs | The file format for the Iceberg table. | `parquet` is the only accepted value. |
+| `external_volume` | String | Yes, except for LRC catalogs | The Cloud Storage bucket where Iceberg table data is written. | For example, `gs://BUCKET_NAME`. |
+| `lakehouse_catalog` | String | No | The name of the Lakehouse Runtime Catalog (LRC) that holds this catalog's tables. | New spec only. Can only be set in `catalogs.yml`. |
 | `base_location_root` | String | No | If provided, the input overrides the default dbt `base_location` value of `_dbt`. | Can be set in `catalogs.yml`. |
 | `base_location_subpath` | String | No | An optional suffix to add to the `base_location` path that dbt automatically specifies. | Only configurable per-model. |
 | `storage_uri` | String | No | If provided, the input overrides the dbt `storage_uri` value. | Only configurable per-model. |
@@ -41,6 +42,7 @@ Supply and nest these additional configurations, unique to BigQuery, under `conf
 - `base_location_root`: Specifies the prefix of the base location path within the storage bucket where Iceberg table data is written.
 - `base_location_subpath`: Specifies the suffix of the base location path within the storage bucket where Iceberg table data is written. This property can only be set in model configurations, not in `catalogs.yml`.
 - `storage_uri`: Completely overrides the storage_uri, allowing you to specify the full path directly instead of using the catalog integration's external volume and base_location components.
+- `lakehouse_catalog`: Tells dbt that this catalog's tables live in a [Lakehouse Runtime Catalog](#lakehouse-runtime-catalog-lrc), so dbt addresses them with BigQuery's four-part name. LRC catalogs don't need `external_volume` or `file_format`, because LRC derives the storage location from the namespace.
 
 ### Example
 
@@ -211,3 +213,97 @@ This behavior could result in future technical debt because it limits the abilit
 - Use a crawler pointed at the tables within the external storage to build a new catalog with another tool
 
 To maintain best practices, dbt enforces an input and, by default, writes your tables within a `_dbt/{SCHEMA_NAME}/{TABLE_NAME}` prefix to ensure easier object-store observability and auditability.
+
+<VersionBlock firstVersion="2.0">
+
+## Lakehouse Runtime Catalog (LRC) <Lifecycle status="beta" />
+
+:::info <Constant name="fusion" /> only
+
+`lakehouse_catalog` requires the [<Constant name="fusion_engine" />](/docs/introduction) (v2) with the `use_catalogs_v2` behavior flag enabled.
+
+<File name='dbt_project.yml'>
+
+```yml
+flags:
+  use_catalogs_v2: true
+```
+
+</File>
+
+:::
+
+BigQuery's [Lakehouse Runtime Catalog](https://cloud.google.com/bigquery/docs/blms-rest-catalog) (LRC) addresses a table with four parts — project, catalog, namespace, and table — but BigQuery SQL only accepts three quoted segments. dbt handles this by quoting the catalog and namespace together as the middle segment:
+
+```sql
+`{project}`.`{catalog}.{namespace}`.`{table}`
+```
+
+Set `lakehouse_catalog` on a `biglake_metastore` catalog to tell dbt that its tables live in an LRC. dbt then uses the four-part name and omits the connection clause and the `table_format` option, neither of which BigQuery accepts for LRC tables.
+
+### Prerequisites
+
+The LRC catalog and namespace must already exist before you run dbt. BigQuery has no SQL statement that creates them, so dbt can only create the table.
+
+Because of this, every run against an LRC catalog logs a warning where dbt attempts to create the namespace and BigQuery rejects it:
+
+```shell
+[FailedToCreateDatabase (dbt1051)]: Failed to create schema 'sales_catalog.analytics' in database
+'my_project' in remote for model.my_project.my_lrc_model: [BigQuery] googleapi: Error 400:
+Invalid project ID 'my_project.sales_catalog'.
+```
+
+This warning is expected and doesn't fail the run. As long as the catalog and namespace exist, dbt creates the table.
+
+### Example
+
+1. Add a catalog with `lakehouse_catalog` set. An LRC catalog doesn't need `external_volume` or `file_format`.
+
+<File name="catalogs.yml">
+
+```yaml
+catalogs:
+  - name: my_lrc_catalog
+    type: biglake_metastore
+    table_format: iceberg
+    config:
+      bigquery:
+        lakehouse_catalog: sales_catalog
+```
+
+</File>
+
+2. Configure a model with `catalog_name`:
+
+<File name="my_lrc_model.sql">
+
+```sql
+
+{{
+    config(
+        materialized='table',
+        catalog_name='my_lrc_catalog'
+    )
+}}
+
+select * from {{ ref('jaffle_shop_customers') }}
+
+```
+
+</File>
+
+3. Run the model: `dbt run -s my_lrc_model`. dbt generates the following DDL:
+
+```sql
+create or replace table `my_project`.`sales_catalog.analytics`.`my_lrc_model`
+  OPTIONS()
+  as (
+    select * from `my_project`.`analytics`.`jaffle_shop_customers`
+  )
+```
+
+### Limitations
+
+BigQuery doesn't expose LRC tables through `INFORMATION_SCHEMA`, so your own queries against those views won't return them. This doesn't affect `dbt docs generate`.
+
+</VersionBlock>

--- a/website/docs/docs/build/iceberg/adapters/bigquery-iceberg-support.md
+++ b/website/docs/docs/build/iceberg/adapters/bigquery-iceberg-support.md
@@ -32,17 +32,17 @@ Supply and nest these additional configurations, unique to BigQuery, under `conf
 
 | Field | Type | Required | Description | Note |
 | ----- | ---- | -------- | ----------- | ---- |
-| `file_format` | String | Yes, except for LRC catalogs | The file format for the Iceberg table. | `parquet` is the only accepted value. |
+| `file_format` | String | Yes, except for [Lakehouse Runtime Catalog (LRC)](#lakehouse-runtime-catalog-lrc) catalogs | The file format for the Iceberg table. | `parquet` is the only accepted value. |
 | `external_volume` | String | Yes, except for LRC catalogs | The Cloud Storage bucket where Iceberg table data is written. | For example, `gs://BUCKET_NAME`. |
-| `lakehouse_catalog` | String | No | The name of the Lakehouse Runtime Catalog (LRC) that holds this catalog's tables. | New spec only. Can only be set in `catalogs.yml`. |
+| `lakehouse_catalog` | String | No | The name of the LRC that holds this catalog's tables. | New spec only, and requires <Constant name="fusion" /> (v2). Set it in `catalogs.yml`, not per model. |
 | `base_location_root` | String | No | If provided, the input overrides the default dbt `base_location` value of `_dbt`. | Can be set in `catalogs.yml`. |
 | `base_location_subpath` | String | No | An optional suffix to add to the `base_location` path that dbt automatically specifies. | Only configurable per-model. |
 | `storage_uri` | String | No | If provided, the input overrides the dbt `storage_uri` value. | Only configurable per-model. |
 
+- `lakehouse_catalog`: Tells dbt that this catalog's tables live in a [Lakehouse Runtime Catalog](#lakehouse-runtime-catalog-lrc), so dbt addresses them with BigQuery's four-part name. LRC catalogs don't need `external_volume` or `file_format` because the LRC derives the storage location from the namespace.
 - `base_location_root`: Specifies the prefix of the base location path within the storage bucket where Iceberg table data is written.
 - `base_location_subpath`: Specifies the suffix of the base location path within the storage bucket where Iceberg table data is written. This property can only be set in model configurations, not in `catalogs.yml`.
 - `storage_uri`: Completely overrides the storage_uri, allowing you to specify the full path directly instead of using the catalog integration's external volume and base_location components.
-- `lakehouse_catalog`: Tells dbt that this catalog's tables live in a [Lakehouse Runtime Catalog](#lakehouse-runtime-catalog-lrc), so dbt addresses them with BigQuery's four-part name. LRC catalogs don't need `external_volume` or `file_format`, because LRC derives the storage location from the namespace.
 
 ### Example
 
@@ -224,7 +224,7 @@ To maintain best practices, dbt enforces an input and, by default, writes your t
 
 <File name='dbt_project.yml'>
 
-```yml
+```yaml
 flags:
   use_catalogs_v2: true
 ```
@@ -233,7 +233,7 @@ flags:
 
 :::
 
-BigQuery's [Lakehouse Runtime Catalog](https://cloud.google.com/bigquery/docs/blms-rest-catalog) (LRC) addresses a table with four parts — project, catalog, namespace, and table — but BigQuery SQL only accepts three quoted segments. dbt handles this by quoting the catalog and namespace together as the middle segment:
+BigQuery's [Lakehouse Runtime Catalog](https://cloud.google.com/bigquery/docs/blms-rest-catalog) (LRC) addresses a table with four parts — project, catalog, namespace, and table — but BigQuery SQL accepts only three quoted segments. dbt handles this by quoting the catalog and namespace together as the middle segment:
 
 ```sql
 `{project}`.`{catalog}.{namespace}`.`{table}`
@@ -243,9 +243,9 @@ Set `lakehouse_catalog` on a `biglake_metastore` catalog to tell dbt that its ta
 
 ### Prerequisites
 
-The LRC catalog and namespace must already exist before you run dbt. BigQuery has no SQL statement that creates them, so dbt can only create the table.
+Create the LRC catalog and namespace before you run dbt. BigQuery has no SQL statement that creates them, so dbt can create only the table.
 
-Because of this, every run against an LRC catalog logs a warning where dbt attempts to create the namespace and BigQuery rejects it:
+Because of this, dbt attempts to create the namespace on every run against an LRC catalog, and BigQuery rejects it with the following warning:
 
 ```shell
 [FailedToCreateDatabase (dbt1051)]: Failed to create schema 'sales_catalog.analytics' in database
@@ -253,9 +253,9 @@ Because of this, every run against an LRC catalog logs a warning where dbt attem
 Invalid project ID 'my_project.sales_catalog'.
 ```
 
-This warning is expected and doesn't fail the run. As long as the catalog and namespace exist, dbt creates the table.
+Expect this warning &mdash; it doesn't fail the run. As long as the catalog and namespace exist, dbt creates the table.
 
-### Example
+### LRC example
 
 1. Add a catalog with `lakehouse_catalog` set. An LRC catalog doesn't need `external_volume` or `file_format`.
 
@@ -302,8 +302,8 @@ create or replace table `my_project`.`sales_catalog.analytics`.`my_lrc_model`
   )
 ```
 
-### Limitations
+### LRC limitations
 
-BigQuery doesn't expose LRC tables through `INFORMATION_SCHEMA`, so your own queries against those views won't return them. This doesn't affect `dbt docs generate`.
+BigQuery doesn't expose LRC tables through `INFORMATION_SCHEMA`, so your queries against those views don't return them. This doesn't affect `dbt docs generate`.
 
 </VersionBlock>

--- a/website/docs/docs/build/iceberg/catalogs-yml.md
+++ b/website/docs/docs/build/iceberg/catalogs-yml.md
@@ -89,7 +89,7 @@ catalogs:
 |-------------------|-------------|-------------------------------|-----------------------------------------------------------------------------------------------|
 | horizon           | snowflake   | snowflake, duckdb             |                                                                                               |
 | glue              | athena      | athena, snowflake, duckdb     |                                                                                               |
-| biglake_metastore | bigquery    | bigquery, snowflake           | Supports BigQuery Lakehouse Runtime Catalog (LRC) tables through [`lakehouse_catalog`](/docs/build/iceberg/adapters/bigquery-iceberg-support#lakehouse-runtime-catalog-lrc) |
+| biglake_metastore | bigquery    | bigquery, snowflake           | Supports BigQuery [Lakehouse Runtime Catalog tables](/docs/build/iceberg/adapters/bigquery-iceberg-support#lakehouse-runtime-catalog-lrc) through the `lakehouse_catalog` config |
 | unity             | databricks  | databricks, snowflake, duckdb | Supports Iceberg (native), Delta, "Uniform" formats                                           |
 | hive_metastore    |             | databricks                    | Supports Hudi format, in addition to Iceberg + Delta                                          |
 | ducklake          |             | duckdb                        |                                                                                               |

--- a/website/docs/docs/build/iceberg/catalogs-yml.md
+++ b/website/docs/docs/build/iceberg/catalogs-yml.md
@@ -89,7 +89,7 @@ catalogs:
 |-------------------|-------------|-------------------------------|-----------------------------------------------------------------------------------------------|
 | horizon           | snowflake   | snowflake, duckdb             |                                                                                               |
 | glue              | athena      | athena, snowflake, duckdb     |                                                                                               |
-| biglake_metastore | bigquery    | bigquery, snowflake           |                                                                                               |
+| biglake_metastore | bigquery    | bigquery, snowflake           | Supports BigQuery Lakehouse Runtime Catalog (LRC) tables through [`lakehouse_catalog`](/docs/build/iceberg/adapters/bigquery-iceberg-support#lakehouse-runtime-catalog-lrc) |
 | unity             | databricks  | databricks, snowflake, duckdb | Supports Iceberg (native), Delta, "Uniform" formats                                           |
 | hive_metastore    |             | databricks                    | Supports Hudi format, in addition to Iceberg + Delta                                          |
 | ducklake          |             | duckdb                        |                                                                                               |


### PR DESCRIPTION
Closes dbt-labs/docs.getdbt.com#9882

## What are you changing in this pull request and why?
- dbt now supports creation of LRC backed tables in BigQuery
- LRC tables require a four part (Project-Catalog-Namespace-Table / PCNT) naming scheme
- Changes is this PR add documentation for managing an LRC table using dbt core v2 (fusion)

## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additional checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->
