### PR TITLE
Clarify built-in Wizard skills load contextually

### DIFF
--- a/website/docs/docs/dbt-ai/wizard-platform-skills.md
+++ b/website/docs/docs/dbt-ai/wizard-platform-skills.md
@@ -92,7 +92,7 @@ In the <Constant name="wizard"/> chat panel:
 
 ## Built-in dbt skills
 
-<Constant name="wizard"/> ships with skills from [dbt Agent Skills](https://github.com/dbt-labs/dbt-agent-skills), maintained by dbt Labs and the community. These capture analytics engineering knowledge for common workflows and are always available. The agent loads the relevant skill automatically when your prompt matches its use case.
+<Constant name="wizard"/> ships with skills from [dbt Agent Skills](https://github.com/dbt-labs/dbt-agent-skills), maintained by dbt Labs and the community. These capture analytics engineering knowledge for common workflows and all ship bundled with <Constant name="wizard"/>. You don't call them directly &mdash; the agent loads whichever one matches your prompt.
 
 For the latest catalog, refer to the [dbt Agent Skills repository](https://github.com/dbt-labs/dbt-agent-skills).
 

--- a/website/docs/docs/dbt-ai/wizard-platform-skills.md
+++ b/website/docs/docs/dbt-ai/wizard-platform-skills.md
@@ -92,7 +92,7 @@ In the <Constant name="wizard"/> chat panel:
 
 ## Built-in dbt skills
 
-<Constant name="wizard"/> ships with skills from [dbt Agent Skills](https://github.com/dbt-labs/dbt-agent-skills), maintained by dbt Labs and the community. These capture analytics engineering knowledge for common workflows and all ship bundled with <Constant name="wizard"/>. You don't call them directly &mdash; the agent loads whichever one matches your prompt.
+<Constant name="wizard"/> ships with skills from [dbt Agent Skills](https://github.com/dbt-labs/dbt-agent-skills), maintained by dbt Labs and the community. These capture analytics engineering knowledge for common workflows and all ship bundled with <Constant name="wizard"/>. You don't call them directly as the agent loads whichever one matches your prompt.
 
 For the latest catalog, refer to the [dbt Agent Skills repository](https://github.com/dbt-labs/dbt-agent-skills).
 

--- a/website/docs/docs/dbt-ai/wizard-skills.md
+++ b/website/docs/docs/dbt-ai/wizard-skills.md
@@ -154,7 +154,7 @@ If a project skill and a global skill use the same name, the project skill takes
 
 <Constant name="wizard"/> ships with skills from [dbt Agent Skills](https://github.com/dbt-labs/dbt-agent-skills), maintained by dbt Labs and the community. These capture analytics engineering knowledge for common workflows and are always available. The agent loads the relevant skill automatically when your prompt matches its use case.
 
-The following skills all ship bundled with <Constant name="wizard"/>. You don't call them directly &mdash; the agent loads whichever one matches your prompt. Refer to the [dbt Agent Skills repository](https://github.com/dbt-labs/dbt-agent-skills) for installation in other AI clients, contributing new skills, and the latest catalog.
+The following skills all ship bundled with <Constant name="wizard"/>. You don't call them directly as the agent loads whichever one best matches your prompt. Refer to the [dbt Agent Skills repository](https://github.com/dbt-labs/dbt-agent-skills) for installation in other AI clients, contributing new skills, and the latest catalog.
 
 <SimpleTable>
 

--- a/website/docs/docs/dbt-ai/wizard-skills.md
+++ b/website/docs/docs/dbt-ai/wizard-skills.md
@@ -154,7 +154,7 @@ If a project skill and a global skill use the same name, the project skill takes
 
 <Constant name="wizard"/> ships with skills from [dbt Agent Skills](https://github.com/dbt-labs/dbt-agent-skills), maintained by dbt Labs and the community. These capture analytics engineering knowledge for common workflows and are always available. The agent loads the relevant skill automatically when your prompt matches its use case.
 
-The following skills are always available and refer to the [dbt Agent Skills repository](https://github.com/dbt-labs/dbt-agent-skills) for installation in other AI clients, contributing new skills, and the latest catalog.
+The following skills all ship bundled with <Constant name="wizard"/>. You don't call them directly &mdash; the agent loads whichever one matches your prompt. Refer to the [dbt Agent Skills repository](https://github.com/dbt-labs/dbt-agent-skills) for installation in other AI clients, contributing new skills, and the latest catalog.
 
 <SimpleTable>
 


### PR DESCRIPTION
Tweaks the "The following skills are always available" line on the [Skills](https://docs.getdbt.com/docs/dbt-ai/wizard-skills#built-in-dbt-skills) page.

The old wording read as if the built-in skills are a static list you invoke directly, which caused confusion (a user saw only `fetching-dbt-docs` surface and thought the rest were missing). In reality all built-in skills ship bundled and load automatically when your prompt matches — you don't call them directly.

New wording makes that clear.