### PR TITLE
Update pip migration copy and pin version

### DIFF
--- a/website/docs/docs/platform/platform-cli-migration.md
+++ b/website/docs/docs/platform/platform-cli-migration.md
@@ -1,36 +1,29 @@
 ---
 title: dbt platform CLI migration
 id: platform-cli-migration
+description: "On September 14, 2026, pip install dbt installs dbt v2 instead of the dbt platform CLI. Learn what to change to keep using the dbt platform CLI without interruption."
 unlisted: true
 ---
 
-The <Constant name="fusion_engine" /> is taking over the `pip install dbt` namespace. If you rely on the <Constant name="platform_cli" />, you need to take action to keep using it without interruption.
+On September 14, 2026, `pip install dbt` installs dbt v2 instead of the <Constant name="platform_cli" />. If you install the <Constant name="platform_cli" /> with pip, you need to take action to keep using it without interruption.
 
 ## What's changing
 
-Starting September 14, 2026 `pip install dbt` will install the <Constant name="fusion_engine" />, dbt's next-generation Rust-based engine, instead of the <Constant name="platform_cli" />. This is a one-time namespace change on PyPI, not a <Constant name="platform_cli" /> upgrade.
+Starting September 14, 2026, `pip install dbt` will install dbt v2, dbt's next-generation Rust-based engine, instead of the <Constant name="platform_cli" />. This is a one-time change to what the `dbt` package on PyPI contains, not a <Constant name="platform_cli" /> upgrade.
 
-If you install the <Constant name="platform_cli" /> using pip today and don't pin a version, your next `pip install dbt` or `pip install --upgrade dbt` installs <Constant name="fusion" /> instead. <Constant name="fusion" /> is a different engine: it runs locally against a warehouse connection you configure yourself, instead of running your commands against your <Constant name="dbt_platform" /> development environment. Commands like `dbt cancel`, `dbt reattach`, `dbt environment`, `dbt sl export`, and `dbt sqlfluff` don't exist in <Constant name="fusion" />.
+If you install the <Constant name="platform_cli" /> using pip today and don't pin a version, your next `pip install dbt` or `pip install --upgrade dbt` installs dbt v2 instead. dbt v2 is a different engine: it runs locally against a warehouse connection you configure yourself, instead of running your commands against your <Constant name="dbt_platform" /> development environment. Commands like `dbt cancel`, `dbt reattach`, `dbt environment`, `dbt sl export`, and `dbt sqlfluff` don't exist in dbt v2.
 
 ## What to do
 
-If you use the <Constant name="platform_cli" /> and want to keep using it, switch to Homebrew:
+If you use the <Constant name="platform_cli" /> and want to keep using it, reinstall it using the current method for your operating system &mdash; Homebrew on macOS, or the native executable on Windows or Linux. Refer to [Install the dbt platform CLI](/docs/platform/dbt-cli-installation) for full instructions.
+
+If you can't reinstall right now (for example, a Docker image that only has pip available), pin your version instead:
 
 ```bash
-brew untap dbt-labs/dbt
-brew tap dbt-labs/dbt-cli
-brew install dbt
+pip install dbt==1.0.0.40.20
 ```
 
-If you have multiple Homebrew taps: `brew install dbt-labs/dbt-cli/dbt`.
-
-If you can't switch to Homebrew right now (for example, a Docker image that only has pip available), pin your version instead:
-
-```bash
-pip install dbt==1.0.0.40.18
-```
-
-This keeps working indefinitely, but won't receive further <Constant name="platform_cli" /> updates through pip. Homebrew is the supported long-term path.
+This keeps working indefinitely, but won't receive further <Constant name="platform_cli" /> updates through pip. Reinstalling with a currently supported method is the long-term path.
 
 ## General areas of impact
 
@@ -41,8 +34,8 @@ This keeps working indefinitely, but won't receive further <Constant name="platf
 
 ## FAQ
 
-- **Why is dbt Labs doing this?** <Constant name="fusion" /> is the new default `dbt` engine going forward. Freeing up the `dbt` name on PyPI for it means new users get <Constant name="fusion" /> by default, matching how `dbt` behaves everywhere else (Homebrew, standalone install).
+- **Why is dbt Labs doing this?** dbt v2 is the new default `dbt` engine going forward. Publishing it under the `dbt` name on PyPI means new users get dbt v2 by default, matching how `dbt` already behaves everywhere else (Homebrew, standalone install).
 
-- **Will my pinned <Constant name="platform_cli" /> version stop working?** No. Pinned installs keep working. They just won't get new <Constant name="platform_cli" /> releases through pip after September 14. For that, move to Homebrew.
+- **Will my pinned <Constant name="platform_cli" /> version stop working?** No. Pinned installs keep working. They just won't get new <Constant name="platform_cli" /> releases through pip after September 14. For that, reinstall using a currently supported method.
 
-- **How do I tell which one I have installed?** `dbt --version`. The <Constant name="platform_cli" /> prints a version like `0.40.18`. <Constant name="fusion" />'s version string needs reconfirming post-update. At the time this article was published, the binary still internally identifies as `dbt-fusion X.Y.Z`, which may change.
+- **How do I tell which one I have installed?** `dbt --version`. The <Constant name="platform_cli" /> prints a version like `0.40.20`; the corresponding version on PyPI is `1.0.0.40.20`. dbt v2's version string needs reconfirming post-update. At the time this article was published, the binary still internally identifies as `dbt-fusion X.Y.Z`, which may change.

--- a/website/docs/docs/platform/platform-cli-migration.md
+++ b/website/docs/docs/platform/platform-cli-migration.md
@@ -1,11 +1,11 @@
 ---
 title: dbt platform CLI migration
 id: platform-cli-migration
-description: "On September 14, 2026, pip install dbt installs dbt v2 instead of the dbt platform CLI. Learn what to change to keep using the dbt platform CLI without interruption."
+description: "Starting September 14, 2026, pip install dbt will install dbt v2 instead of the dbt platform CLI. Learn what to change to keep using the dbt platform CLI without interruption."
 unlisted: true
 ---
 
-On September 14, 2026, `pip install dbt` installs dbt v2 instead of the <Constant name="platform_cli" />. If you install the <Constant name="platform_cli" /> with pip, you need to take action to keep using it without interruption.
+Starting September 14, 2026, `pip install dbt` will install dbt v2 instead of the <Constant name="platform_cli" />. If you install the <Constant name="platform_cli" /> with pip, you need to take action to keep using it without interruption.
 
 ## What's changing
 
@@ -15,7 +15,7 @@ If you install the <Constant name="platform_cli" /> using pip today and don't pi
 
 ## What to do
 
-If you use the <Constant name="platform_cli" /> and want to keep using it, reinstall it using the current method for your operating system &mdash; Homebrew on macOS, or the native executable on Windows or Linux. Refer to [Install the dbt platform CLI](/docs/platform/dbt-cli-installation) for full instructions.
+If you use the <Constant name="platform_cli" /> and want to keep using it, reinstall it using the current method for your operating system &mdash; Homebrew on macOS, or the native executable on Windows or Linux. Refer to [Install the <Constant name="platform_cli" />](/docs/platform/dbt-cli-installation) for full instructions.
 
 If you can't reinstall right now (for example, a Docker image that only has pip available), pin your version instead:
 
@@ -38,4 +38,4 @@ This keeps working indefinitely, but won't receive further <Constant name="platf
 
 - **Will my pinned <Constant name="platform_cli" /> version stop working?** No. Pinned installs keep working. They just won't get new <Constant name="platform_cli" /> releases through pip after September 14. For that, reinstall using a currently supported method.
 
-- **How do I tell which one I have installed?** `dbt --version`. The <Constant name="platform_cli" /> prints a version like `0.40.20`; the corresponding version on PyPI is `1.0.0.40.20`. dbt v2's version string needs reconfirming post-update. At the time this article was published, the binary still internally identifies as `dbt-fusion X.Y.Z`, which may change.
+- **How do I tell which one I have installed?** `dbt --version`. The <Constant name="platform_cli" /> prints a version like `0.40.20`; the corresponding version on PyPI is `1.0.0.40.20`. dbt v2's version string needs reconfirming post-update. At the time this article was published, dbt v2's binary still internally identifies as `dbt-fusion X.Y.Z`, which may change.


### PR DESCRIPTION
## What are you changing in this pull request and why?

Copy and version updates to the pip migration guide, ahead of the customer comms going out before September 14.

- Fusion naming replaced with dbt v2
- Dropped "taking over the namespace" and "freeing up the `dbt` name". We keep the `dbt` project on PyPI either way, only the published distribution changes
- "What to do" now covers Windows and Linux. The installation docs added native executables on Aug 25, so this page only worked for macOS. Links there instead of repeating the brew commands
- Pin bumped to `1.0.0.40.20`, showing both the PyPI version and the `dbt --version` output
- Added a frontmatter `description`. Constants render blank in meta tags, so search results read "The  is taking over the pip install dbt namespace"

One to confirm before merge: the `0.40.20` in the FAQ is inferred from the old `0.40.18` following the pin bump. Worth a check on what `dbt --version` actually prints.

## Checklist

- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/release-notes).).

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-platform-cli-migration-copy-dbt-labs.vercel.app/docs/configure-dbt-extension
- https://docs-getdbt-com-git-platform-cli-migration-copy-dbt-labs.vercel.app/docs/dbt-versions/dbt-platform-release-notes-gen
- https://docs-getdbt-com-git-platform-cli-migration-copy-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/01-upgrading-to-v2
- https://docs-getdbt-com-git-platform-cli-migration-copy-dbt-labs.vercel.app/docs/deploy/advanced-ci
- https://docs-getdbt-com-git-platform-cli-migration-copy-dbt-labs.vercel.app/docs/deploy/run-visibility
- https://docs-getdbt-com-git-platform-cli-migration-copy-dbt-labs.vercel.app/docs/platform/platform-cli-migration

<!-- end-vercel-deployment-preview -->