### PR TITLE
Fix inaccurate caption in microbatch documentation

### DIFF
--- a/website/docs/docs/build/incremental-microbatch.md
+++ b/website/docs/docs/build/incremental-microbatch.md
@@ -189,7 +189,7 @@ dbt will instruct the data platform to take the result of each batch query and [
 
 It does not matter whether the table already contains data for that day. Given the same input data, the resulting table is the same no matter how many times a batch is reprocessed.
 
-<Lightbox src="/img/docs/building-a-dbt-project/microbatch/microbatch_filters.png" title="Each batch of sessions filters page_views to the matching time-bound batch, but doesn't filter sessions, performing a full scan for each batch."/>
+<Lightbox src="/img/docs/building-a-dbt-project/microbatch/microbatch_filters.png" title="Each batch of sessions filters page_views to the matching time-bound batch, but doesn't filter customers, performing a full scan for each batch."/>
 
 ## Relevant configs
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Fix an inaccurate caption in the microbatch documentation. The caption incorrectly refers to filtering “sessions,” while the image and the surrounding logic refer to filtering “customers.” This change updates “sessions” to “customers” so the caption accurately reflects the documented behavior.

## Checklist

- [x] The changes in this PR meet the docs style guide/fundamentals required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s).
- [ ] The content in this PR requires a dbt release note, so I added one to the release notes page.