### PR TITLE
[dbt State] Python models and custom materializations

### DIFF
--- a/website/docs/docs/deploy/dbt-state-about.md
+++ b/website/docs/docs/deploy/dbt-state-about.md
@@ -19,7 +19,10 @@ dbt State makes dbt smarter about what to build. Instead of rebuilding every nod
 
 With dbt State, dbt first compares the logic and data of each node to previous builds across multiple environments on every run &mdash; whether orchestrated in the <Constant name="dbt_platform" />, through your own orchestrator, or in development. If the logic is the same and the data is still fresh, dbt reuses an existing object. It will either clone an existing node from elsewhere, or skip executing a model that already exists, rather than building it anew. Additionally, it will automatically defer to production state without the need to manually set the `--defer` or `--state` flags.
 
-dbt State can reuse all node types that create relations in the database (such as models, snapshots, seeds) and data tests.
+dbt State can reuse all node types that create relations in the database (such as SQL models, snapshots, seeds) and data tests. Note that the following models are not eligible for reuse:
+
+- **Python models**: dbt State builds Python models on every run, even if their code and upstream data have not changed.
+- **Models with custom materializations**: dbt State builds these models on every run because custom materializations may have side effects (for example, modifying table properties or writing to other schemas), and dbt State cannot safely determine whether skipping the run would produce the same result.
 
 dbt State works with dbt (v1 and v2) and the <Constant name="dbt_platform" />, across all environments and orchestrators, making it a flexible approach regardless of how you run dbt. It requires authentication through a <Constant name="dbt_platform" /> account. For pricing details, refer to [dbt State usage and pricing](/docs/platform/billing/dbt-state-usage).
 
@@ -74,6 +77,7 @@ dbt State is connected to your existing <Constant name="dbt_platform" /> account
 <FAQ path="Runs/what-happened-to-sao" />
 <FAQ path="State/state-modified-difference" />
 <FAQ path="State/incremental-models" />
+<FAQ path="State/python-models" />
 <FAQ path="State/data-storage" />
 <FAQ path="State/last-updated-timestamp" />
 <FAQ path="State/model-change-calculation" />

--- a/website/docs/faqs/State/python-models.md
+++ b/website/docs/faqs/State/python-models.md
@@ -1,0 +1,8 @@
+---
+title: Does dbt State support Python models?
+description: "Learn how dbt State works with Python models."
+sidebar_label: 'Does State support Python models?'
+id: python-models
+---
+
+dbt State builds Python models but does not reuse them. It executes Python models on every run, even when their code and upstream data have not changed.

--- a/website/docs/faqs/State/views-rebuilt.md
+++ b/website/docs/faqs/State/views-rebuilt.md
@@ -14,6 +14,7 @@ The following patterns commonly cause unexpected rebuilds:
 - [Views with `select *`](#views-with-select)
 - [Non-deterministic Jinja templating](#non-deterministic-jinja-templating)
 - [Models with external sources in BigQuery](#models-with-external-sources-in-bigquery)
+- [Models with custom materializations](#models-with-custom-materializations)
 
 ## Views with `select *` {#views-with-select}
 
@@ -84,6 +85,10 @@ On BigQuery, models that use external sources (such as Google Sheets) always reb
 :::tip
 To prevent external sources from always being considered stale, configure [`loaded_at_field`](/reference/resource-properties/freshness#loaded_at_field) or [`loaded_at_query`](/reference/resource-properties/freshness#loaded_at_query) in your source definition to point to a timestamp field. This lets dbt State query a timestamp field directly to determine freshness, rather than relying on warehouse metadata.
 :::
+
+## Models with custom materializations
+
+Models using custom materializations are always built and are never reused. Custom materializations may have side effects (for example, modifying table properties or writing to other schemas), and dbt State cannot safely determine whether skipping the run would produce the same result.
 
 ## How to diagnose
 


### PR DESCRIPTION
## What are you changing in this pull request and why?

Documents two limitations on dbt State reuse: Python models and models with custom materializations are always built on every run and are never eligible for reuse.

### Changes per file

**`docs/deploy/dbt-state-about.md`**
Updated the description of which node types dbt State can reuse. Added a list noting that Python models and models with custom materializations are always built — Python models because dbt State has no way to determine whether their output has changed, and custom materializations because they may have side effects (such as DDL statements or cross-schema operations) that dbt State cannot safely account for.

**`faqs/State/python-models.md`** _(new)_
New FAQ — "Does dbt State support Python models?" — explaining that Python models are built but not reused on every run, unlike SQL models.

**`faqs/State/views-rebuilt.md`**
Added a new section — "Models with custom materializations" — to the existing FAQ on unexpected rebuilds, explaining why custom materializations are always executed and never reused.

### Preview links

- [About dbt State](https://docs-getdbt-com-git-state-caveats-dbt-labs.vercel.app/docs/deploy/dbt-state-about)
- [Does dbt State support Python models?](https://docs-getdbt-com-git-state-caveats-dbt-labs.vercel.app/faqs/State/python-models)
- [Why is my model being rebuilt instead of reused?](https://docs-getdbt-com-git-state-caveats-dbt-labs.vercel.app/faqs/State/views-rebuilt)

## Checklist
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s).
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/release-notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)