### PR TITLE
Fix v2 dimension examples that show expr in the dimensions block

### DIFF
--- a/website/docs/docs/build/dimensions.md
+++ b/website/docs/docs/build/dimensions.md
@@ -25,9 +25,10 @@ Dimensions represent the non-aggregatable columns in your data set, which are th
 
 Groups are defined within semantic models, alongside entities and measures, and correspond to non-aggregatable columns in your dbt model that provides categorical or time-based context. In SQL, dimensions  is typically included in the GROUP BY clause.-->
 
+<VersionBlock lastVersion="1.11">
+
 All dimensions require a `name`, `type`, and can optionally include an `expr` parameter. The `name` for your Dimension must be unique within the same semantic model.
 
-<VersionBlock lastVersion="1.11">
 
 | Parameter | Description | Required | Type |
 | --------- | ----------- | ---- | ---- |
@@ -55,12 +56,17 @@ dimensions:
 
 <VersionBlock firstVersion="1.12">
 
+Dimensions are defined on the column they map to, so they only require a `type`. The `name` defaults to the column name and must be unique within the same semantic model.
+
+:::note
+You can't use `expr` inside a `dimension` block. To define a dimension from a SQL expression instead of a single column, use [`derived_semantics`](#derived_semantics-in-dimensions).
+:::
+
 | Parameter | Description | Required | Type |
 | --------- | ----------- | ---- | ---- |
-| `name` |  The name of the dimension that will be visible to the user in downstream tools. It can also serve as an alias for derived dimensions <br /><br /> Dimension names should be unique within a semantic model, but they can be non-unique across different models as MetricFlow uses [joins](/docs/build/join-logic) to identify the right dimension. | Required | String |
+| `name` |  The name of the dimension that will be visible to the user in downstream tools. It can also serve as an alias for derived dimensions <br /><br /> Dimension names should be unique within a semantic model, but they can be non-unique across different models as MetricFlow uses [joins](/docs/build/join-logic) to identify the right dimension. | Optional (defaults to the column name) | String |
 | `type` | Specifies the type of group created in the semantic model. There are two types:<br /><br />- **Categorical**: Describe attributes or features like geography or sales region. <br />- **Time**: Time-based dimensions like timestamps or dates. | Required | String |  
 | `description` | A clear description of the dimension. | Optional | String |  
-| `expr` | Defines the underlying column or SQL query for a dimension. If no `expr` is specified, MetricFlow will use the column with the same name as the group. You can use the column name itself to input a SQL expression. | Optional | String |
 | `label` | Defines the display value in downstream tools. Accepts plain text, spaces, and quotes (such as `orders_total` or `"orders_total"`).  | Optional | String |
 | [`meta`](/reference/resource-configs/meta) |  Set metadata for a resource and organize resources. Accepts plain text, spaces, and quotes. | Optional | Dictionary | 
 
@@ -259,9 +265,11 @@ This section further explains the dimension definitions, along with examples. Di
 
 ## Categorical
 
-Categorical dimensions are used to group metrics by different attributes, features, or characteristics such as product type. They can refer to existing columns in your dbt model or be calculated using a SQL expression with the `expr` parameter. An example of a categorical dimension is `is_bulk_transaction`, which is a group created by applying a case statement to the underlying column `quantity`. This allows users to group or filter the data based on bulk transactions.
+Categorical dimensions are used to group metrics by different attributes, features, or characteristics such as product type.
 
-<VersionBlock firstVersion="1.9">
+<VersionBlock firstVersion="1.9" lastVersion="1.11">
+
+They can refer to existing columns in your dbt model or be calculated using a SQL expression with the `expr` parameter. An example of a categorical dimension is `is_bulk_transaction`, which is a group created by applying a case statement to the underlying column `quantity`. This allows users to group or filter the data based on bulk transactions.
 
 ```yaml
 dimensions: 
@@ -272,6 +280,42 @@ dimensions:
       meta:
         usage: "Filter to identify bulk transactions, like where quantity > 10."
 ```
+</VersionBlock>
+
+<VersionBlock firstVersion="1.12">
+
+Define a categorical dimension on the column it maps to. For example, the `transaction_type` column becomes a dimension you can group or filter metrics by:
+
+```yaml
+models:
+  - name: fact_transactions
+    semantic_model:
+      enabled: true
+
+    columns:
+      - name: transaction_type
+        dimension:
+          type: categorical
+          config:
+            meta:
+              usage: "Group transactions by their type, like refund or purchase."
+```
+
+To calculate a categorical dimension from a SQL expression instead of a single column, define it under [`derived_semantics`](#derived_semantics-in-dimensions) and use `expr`. For example, `is_bulk_transaction` applies a case statement to the underlying `quantity` column so users can group or filter by bulk transactions:
+
+```yaml
+models:
+  - name: fact_transactions
+    semantic_model:
+      enabled: true
+
+    derived_semantics:
+      dimensions:
+        - name: is_bulk_transaction
+          type: categorical
+          expr: "case when quantity > 10 then true else false end"
+```
+
 </VersionBlock>
 
 


### PR DESCRIPTION
Fixes #9931

The v2 (1.12+) dimensions docs showed `expr` inside a `dimension` block, which the new spec rejects. `expr` only works under `derived_semantics`.

What changed on [Dimensions](https://docs.getdbt.com/docs/build/dimensions?version=2):

- Removed the `expr` row from the v2 parameter table and added a note pointing to `derived_semantics`.
- Split the Categorical section by version. v2 now has a column-based example plus a `derived_semantics` example for SQL expressions; the 1.9–1.11 example is unchanged.
- Version-gated the "All dimensions require a `name`, `type`, and can optionally include an `expr`" line so it only shows for 1.11 and earlier, and clarified that in v2 `name` defaults to the column name.

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-fix-v2-dimension-expr-dbt-labs.vercel.app/docs/build/dimensions

<!-- end-vercel-deployment-preview -->