### PR TITLE
Don't add version param to blog links

### DIFF
--- a/website/src/stores/VersionContext.js
+++ b/website/src/stores/VersionContext.js
@@ -62,11 +62,10 @@ export const VersionContextProvider = ({ value = "", children }) => {
 
   // Helper to update URL with the version parameter
   const updateUrlParams = useCallback((newSubProductName) => {
+    // Blog posts aren't versioned content, so never add a version param there
+    if (location.pathname.startsWith('/blog')) return
+
     const url = new URL(window.location.href)
-
-    // Don't add a version param to blog pages that don't already have query params
-    if (location.pathname.startsWith('/blog') && !url.search) return
-
     const sp = findSubProduct(newSubProductName);
 
     // Strip legacy params that are no longer written to the URL

--- a/website/src/stores/VersionContext.js
+++ b/website/src/stores/VersionContext.js
@@ -63,6 +63,10 @@ export const VersionContextProvider = ({ value = "", children }) => {
   // Helper to update URL with the version parameter
   const updateUrlParams = useCallback((newSubProductName) => {
     const url = new URL(window.location.href)
+
+    // Don't add a version param to blog pages that don't already have query params
+    if (location.pathname.startsWith('/blog') && !url.search) return
+
     const sp = findSubProduct(newSubProductName);
 
     // Strip legacy params that are no longer written to the URL
@@ -82,7 +86,7 @@ export const VersionContextProvider = ({ value = "", children }) => {
     }
 
     window.history.replaceState({}, '', url.toString())
-  }, [])
+  }, [location.pathname])
 
   // Resolve a subProduct name from URL search params
   const resolveSubProductFromSearch = useCallback((search) => {

--- a/website/src/utils/useVersionUrlSync.js
+++ b/website/src/utils/useVersionUrlSync.js
@@ -14,11 +14,10 @@ export function useVersionUrlSync() {
     // Only run on client side and when we have a version
     if (typeof window === 'undefined' || !urlVersion) return;
 
+    // Blog posts aren't versioned content, so never add a version param there
+    if (location.pathname.startsWith('/blog')) return;
+
     const url = new URL(window.location.href);
-
-    // Don't add a version param to blog pages that don't already have query params
-    if (location.pathname.startsWith('/blog') && !url.search) return;
-
     const currentVersionParam = url.searchParams.get('version');
 
     // Only update if the version param is missing or different

--- a/website/src/utils/useVersionUrlSync.js
+++ b/website/src/utils/useVersionUrlSync.js
@@ -15,6 +15,10 @@ export function useVersionUrlSync() {
     if (typeof window === 'undefined' || !urlVersion) return;
 
     const url = new URL(window.location.href);
+
+    // Don't add a version param to blog pages that don't already have query params
+    if (location.pathname.startsWith('/blog') && !url.search) return;
+
     const currentVersionParam = url.searchParams.get('version');
 
     // Only update if the version param is missing or different


### PR DESCRIPTION
I frequently link to blog posts, and don't want them to have the version suffix because it's not relevant for articles.