### PR TITLE
AWS S3 Tables

### DIFF
--- a/website/docs/docs/build/iceberg/catalogs-yml.md
+++ b/website/docs/docs/build/iceberg/catalogs-yml.md
@@ -89,6 +89,7 @@ catalogs:
 |-------------------|-------------|-------------------------------|-----------------------------------------------------------------------------------------------|
 | horizon           | snowflake   | snowflake, duckdb             |                                                                                               |
 | glue              | athena      | athena, snowflake, duckdb     |                                                                                               |
+| s3_tables         |             | athena                        | Amazon S3 Tables managed Iceberg catalogs for Athena (`dbt-athena` 1.11.1 and later). Refer to [AWS S3 Tables](/reference/resource-configs/athena-configs#aws-s3-tables). |
 | biglake_metastore | bigquery    | bigquery, snowflake           | Supports BigQuery [Lakehouse Runtime Catalog tables](/docs/build/iceberg/adapters/bigquery-iceberg-support#lakehouse-runtime-catalog-lrc) through the `lakehouse_catalog` config |
 | unity             | databricks  | databricks, snowflake, duckdb | Supports Iceberg (native), Delta, "Uniform" formats                                           |
 | hive_metastore    |             | databricks                    | Supports Hudi format, in addition to Iceberg + Delta                                          |

--- a/website/docs/docs/build/iceberg/catalogs-yml.md
+++ b/website/docs/docs/build/iceberg/catalogs-yml.md
@@ -88,8 +88,8 @@ catalogs:
 | catalog `type`    | default for | supported by                  | Notes                                                                                         |
 |-------------------|-------------|-------------------------------|-----------------------------------------------------------------------------------------------|
 | horizon           | snowflake   | snowflake, duckdb             |                                                                                               |
-| glue              | athena      | athena, snowflake, duckdb     |                                                                                               |
-| s3_tables         |             | athena                        | Amazon S3 Tables managed Iceberg catalogs for Athena (`dbt-athena` 1.11.1 and later). Refer to [AWS S3 Tables](/reference/resource-configs/athena-configs#aws-s3-tables). |
+| glue              | athena      | athena, snowflake, duckdb     | Default catalog type for Athena. Refer to [Iceberg catalogs](/reference/resource-configs/athena-configs#iceberg-catalogs). |
+| s3_tables         |             | athena                        | Amazon S3 Tables managed Iceberg catalogs for Athena (`dbt-athena` 1.11.1 and later). Refer to [Iceberg catalogs](/reference/resource-configs/athena-configs#iceberg-catalogs) and [AWS S3 Tables](/reference/resource-configs/athena-configs#aws-s3-tables). |
 | biglake_metastore | bigquery    | bigquery, snowflake           | Supports BigQuery [Lakehouse Runtime Catalog tables](/docs/build/iceberg/adapters/bigquery-iceberg-support#lakehouse-runtime-catalog-lrc) through the `lakehouse_catalog` config |
 | unity             | databricks  | databricks, snowflake, duckdb | Supports Iceberg (native), Delta, "Uniform" formats                                           |
 | hive_metastore    |             | databricks                    | Supports Hudi format, in addition to Iceberg + Delta                                          |

--- a/website/docs/reference/resource-configs/athena-configs.md
+++ b/website/docs/reference/resource-configs/athena-configs.md
@@ -188,79 +188,6 @@ select 'A'          as user_id,
 
 In `dbt-athena` 1.11.1 and later, you can define Iceberg catalogs in `catalogs.yml` and select one with `catalog_name` on a model. The default catalog type for Athena is `glue`. Refer to [Using catalogs.yml](/docs/build/iceberg/catalogs-yml) for the `catalogs.yml` format.
 
-#### AWS S3 Tables
-
-In `dbt-athena` 1.11.1 and later, you can write Iceberg models to [Amazon S3 Tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables.html) by defining a catalog with `type: s3_tables` in `catalogs.yml` and setting `catalog_name` on the model. Set `catalog_database` to the catalog name Athena uses for your table bucket (`s3tablescatalog/YOUR_TABLE_BUCKET`). The model's schema is the S3 Tables namespace.
-
-##### Prerequisites
-
-- `dbt-athena` 1.11.1 or later, and a dbt version that supports `use_catalogs_v2` (1.12 or later) if you use the recommended `catalogs.yml` format
-- An [S3 Tables table bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-buckets.html)
-- AWS Glue integration enabled for that bucket, so it appears as `s3tablescatalog/YOUR_TABLE_BUCKET`. Without it, the catalog won't resolve.
-- A namespace in the table bucket that matches the schema dbt uses for the model. dbt doesn't create S3 Tables namespaces for you.
-- An IAM role with S3 Tables read and write access, plus Glue permissions to create and delete tables in that catalog
-
-##### Configure the catalog
-
-For the recommended `catalogs.yml` format, enable the `use_catalogs_v2` flag. Refer to [Using catalogs.yml](/docs/build/iceberg/catalogs-yml).
-
-<File name='dbt_project.yml'>
-
-```yml
-flags:
-  use_catalogs_v2: true
-```
-
-</File>
-
-<File name='catalogs.yml'>
-
-```yml
-catalogs:
-  - name: my_s3_tables
-    type: s3_tables
-    table_format: iceberg
-    config:
-      athena:
-        catalog_database: s3tablescatalog/my-table-bucket
-```
-
-</File>
-
-If you use the older `catalogs.yml` format (without `use_catalogs_v2`), configure the same catalog with `write_integrations`:
-
-<File name='catalogs.yml'>
-
-```yml
-catalogs:
-  - name: my_s3_tables
-    active_write_integration: s3_tables
-    write_integrations:
-      - name: s3_tables
-        catalog_type: s3_tables
-        table_format: iceberg
-        catalog_database: s3tablescatalog/my-table-bucket
-```
-
-</File>
-
-Then point the model at that catalog:
-
-```sql
-{{ config(
-    materialized='table',
-    catalog_name='my_s3_tables'
-) }}
-
-select 1 as id
-```
-
-##### Considerations
-
-- Python models aren't supported for S3 Tables catalogs.
-- `external_location`, `s3_data_dir`, and `s3_data_naming` are ignored. S3 Tables manages storage.
-- Table replacement uses drop and recreate. S3 Tables doesn't support `ALTER TABLE RENAME`, so the Iceberg high-availability behavior described in [High availability (HA) table](#high-availability-ha-table) doesn't apply.
-
 Iceberg supports bucketing as hidden partitions. Use the `partitioned_by` config to add specific bucketing
 conditions.
 
@@ -362,6 +289,63 @@ select * from (
 </TabItem>
 
 </Tabs>
+
+#### AWS S3 Tables
+
+In `dbt-athena` 1.11.1 and later, you can write Iceberg models to [Amazon S3 Tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables.html) by defining a catalog with `type: s3_tables` in `catalogs.yml` and setting `catalog_name` on the model. Set `catalog_database` to the catalog name Athena uses for your table bucket (`s3tablescatalog/YOUR_TABLE_BUCKET`). The model's schema is the S3 Tables namespace.
+
+##### Prerequisites
+
+- `dbt-athena` 1.11.1 or later, and <Constant name="core" /> 1.12 or later with `use_catalogs_v2` enabled (`catalog_database` requires this)
+- An [S3 Tables table bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-buckets.html)
+- AWS Glue integration enabled for that bucket, so it appears as `s3tablescatalog/YOUR_TABLE_BUCKET`. Without it, the catalog won't resolve.
+- A namespace in the table bucket that matches the schema dbt uses for the model. dbt doesn't create S3 Tables namespaces for you.
+- An IAM role with S3 Tables read and write access, plus Glue permissions to create and delete tables in that catalog
+
+##### Configure the catalog
+
+Enable the `use_catalogs_v2` flag, then define the catalog. Refer to [Using catalogs.yml](/docs/build/iceberg/catalogs-yml).
+
+<File name='dbt_project.yml'>
+
+```yml
+flags:
+  use_catalogs_v2: true
+```
+
+</File>
+
+<File name='catalogs.yml'>
+
+```yml
+catalogs:
+  - name: my_s3_tables
+    type: s3_tables
+    table_format: iceberg
+    config:
+      athena:
+        catalog_database: s3tablescatalog/my-table-bucket
+```
+
+</File>
+
+Then point the model at that catalog:
+
+```sql
+{{ config(
+    materialized='table',
+    catalog_name='my_s3_tables'
+) }}
+
+select 1 as id
+```
+
+##### Considerations
+
+- The `table`, `incremental`, and `snapshot` materializations are supported.
+- Python models aren't supported for S3 Tables catalogs.
+- `external_location`, `s3_data_dir`, and `s3_data_naming` are ignored. S3 Tables manages storage.
+- Table replacement uses drop and recreate. S3 Tables doesn't support `ALTER TABLE RENAME`, so the Iceberg high-availability behavior described in [High availability (HA) table](#high-availability-ha-table) doesn't apply.
 
 ### High availability (HA) table
 

--- a/website/docs/reference/resource-configs/athena-configs.md
+++ b/website/docs/reference/resource-configs/athena-configs.md
@@ -184,11 +184,25 @@ select 'A'          as user_id,
        current_date as my_date
 ```
 
+#### Iceberg catalogs
+
+In `dbt-athena` 1.11.1 and later, you can define Iceberg catalogs in `catalogs.yml` and select one with `catalog_name` on a model. The default catalog type for Athena is `glue`. Refer to [Using catalogs.yml](/docs/build/iceberg/catalogs-yml) for the `catalogs.yml` format.
+
 #### AWS S3 Tables
 
-In `dbt-athena` 1.11.1 and later, you can write Iceberg models to [Amazon S3 Tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables.html) by defining a catalog with `type: s3_tables` in `catalogs.yml` and setting `catalog_name` on the model. Set `catalog_database` to the federated catalog name for your table bucket (`s3tablescatalog/YOUR_TABLE_BUCKET`). The model's `schema` is the S3 Tables namespace.
+In `dbt-athena` 1.11.1 and later, you can write Iceberg models to [Amazon S3 Tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables.html) by defining a catalog with `type: s3_tables` in `catalogs.yml` and setting `catalog_name` on the model. Set `catalog_database` to the catalog name Athena uses for your table bucket (`s3tablescatalog/YOUR_TABLE_BUCKET`). The model's schema is the S3 Tables namespace.
 
-For the recommended `catalogs.yml` format, enable the v2 flag. Refer to [Using catalogs.yml](/docs/build/iceberg/catalogs-yml).
+##### Prerequisites
+
+- `dbt-athena` 1.11.1 or later, and a dbt version that supports `use_catalogs_v2` (1.12 or later) if you use the recommended `catalogs.yml` format
+- An [S3 Tables table bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables-buckets.html)
+- AWS Glue integration enabled for that bucket, so it appears as `s3tablescatalog/YOUR_TABLE_BUCKET`. Without it, the catalog won't resolve.
+- A namespace in the table bucket that matches the schema dbt uses for the model. dbt doesn't create S3 Tables namespaces for you.
+- An IAM role with S3 Tables read and write access, plus Glue permissions to create and delete tables in that catalog
+
+##### Configure the catalog
+
+For the recommended `catalogs.yml` format, enable the `use_catalogs_v2` flag. Refer to [Using catalogs.yml](/docs/build/iceberg/catalogs-yml).
 
 <File name='dbt_project.yml'>
 
@@ -209,12 +223,11 @@ catalogs:
     config:
       athena:
         catalog_database: s3tablescatalog/my-table-bucket
-        file_format: parquet
 ```
 
 </File>
 
-If you use the older `catalogs.yml` spec (without `use_catalogs_v2`), configure the same catalog with `write_integrations`:
+If you use the older `catalogs.yml` format (without `use_catalogs_v2`), configure the same catalog with `write_integrations`:
 
 <File name='catalogs.yml'>
 
@@ -226,7 +239,6 @@ catalogs:
       - name: s3_tables
         catalog_type: s3_tables
         table_format: iceberg
-        file_format: parquet
         catalog_database: s3tablescatalog/my-table-bucket
 ```
 
@@ -237,12 +249,17 @@ Then point the model at that catalog:
 ```sql
 {{ config(
     materialized='table',
-    catalog_name='my_s3_tables',
-    schema='my_namespace'
+    catalog_name='my_s3_tables'
 ) }}
 
 select 1 as id
 ```
+
+##### Considerations
+
+- Python models aren't supported for S3 Tables catalogs.
+- `external_location`, `s3_data_dir`, and `s3_data_naming` are ignored. S3 Tables manages storage.
+- Table replacement uses drop and recreate. S3 Tables doesn't support `ALTER TABLE RENAME`, so the Iceberg high-availability behavior described in [High availability (HA) table](#high-availability-ha-table) doesn't apply.
 
 Iceberg supports bucketing as hidden partitions. Use the `partitioned_by` config to add specific bucketing
 conditions.
@@ -348,7 +365,7 @@ select * from (
 
 ### High availability (HA) table
 
-The current implementation of table materialization can lead to downtime, as the target table is dropped and re-created. For less destructive behavior, you can use the `ha` config on your `table` materialized models. It leverages the table versions feature of the glue catalog, which creates a temporary table and swaps the target table to the location of the temporary table. This materialization is only available for `table_type=hive` and requires using unique locations. For Iceberg, high availability is the default.
+The current implementation of table materialization can lead to downtime, as the target table is dropped and re-created. For less destructive behavior, you can use the `ha` config on your `table` materialized models. It leverages the table versions feature of the glue catalog, which creates a temporary table and swaps the target table to the location of the temporary table. This materialization is only available for `table_type=hive` and requires using unique locations. For Iceberg, high availability is the default, except for [AWS S3 Tables](#aws-s3-tables) catalogs, which use drop and recreate instead.
 
 By default, the materialization keeps the last 4 table versions,but you can change it by setting `versions_to_keep`.
 

--- a/website/docs/reference/resource-configs/athena-configs.md
+++ b/website/docs/reference/resource-configs/athena-configs.md
@@ -184,6 +184,66 @@ select 'A'          as user_id,
        current_date as my_date
 ```
 
+#### AWS S3 Tables
+
+In `dbt-athena` 1.11.1 and later, you can write Iceberg models to [Amazon S3 Tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables.html) by defining a catalog with `type: s3_tables` in `catalogs.yml` and setting `catalog_name` on the model. Set `catalog_database` to the federated catalog name for your table bucket (`s3tablescatalog/YOUR_TABLE_BUCKET`). The model's `schema` is the S3 Tables namespace.
+
+For the recommended `catalogs.yml` format, enable the v2 flag. Refer to [Using catalogs.yml](/docs/build/iceberg/catalogs-yml).
+
+<File name='dbt_project.yml'>
+
+```yml
+flags:
+  use_catalogs_v2: true
+```
+
+</File>
+
+<File name='catalogs.yml'>
+
+```yml
+catalogs:
+  - name: my_s3_tables
+    type: s3_tables
+    table_format: iceberg
+    config:
+      athena:
+        catalog_database: s3tablescatalog/my-table-bucket
+        file_format: parquet
+```
+
+</File>
+
+If you use the older `catalogs.yml` spec (without `use_catalogs_v2`), configure the same catalog with `write_integrations`:
+
+<File name='catalogs.yml'>
+
+```yml
+catalogs:
+  - name: my_s3_tables
+    active_write_integration: s3_tables
+    write_integrations:
+      - name: s3_tables
+        catalog_type: s3_tables
+        table_format: iceberg
+        file_format: parquet
+        catalog_database: s3tablescatalog/my-table-bucket
+```
+
+</File>
+
+Then point the model at that catalog:
+
+```sql
+{{ config(
+    materialized='table',
+    catalog_name='my_s3_tables',
+    schema='my_namespace'
+) }}
+
+select 1 as id
+```
+
 Iceberg supports bucketing as hidden partitions. Use the `partitioned_by` config to add specific bucketing
 conditions.
 


### PR DESCRIPTION
This adds documentation for [Amazon S3 Tables](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-tables.html) support as an Iceberg catalog for Athena, available in `dbt-athena` 1.11.1 and later.

- **`docs/build/iceberg/catalogs-yml.md`**: Adds `s3_tables` to the catalog type compatibility table, linking to the new reference section below.
- **`reference/resource-configs/athena-configs.md`**: Adds a new "AWS S3 Tables" section explaining how to:
  - Define an S3 Tables catalog in `catalogs.yml` using the recommended v2 format (`use_catalogs_v2: true`)
  - Configure the same catalog using the older `write_integrations` spec, for users not yet on v2
  - Point a model at the catalog via the `catalog_name` and `schema` configs

## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additional checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/best-practices/how-we-handle-real-time-data/2-incremental-patterns
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/about-dbt-extension
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/about-dbt-lsp
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/build/iceberg/catalogs-yml
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/build/incremental-microbatch
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/build/incremental-strategy
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/build/metricflow-commands
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/build/snapshots
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/build/udfs
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/build/unit-tests
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/configure-dbt-extension
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/dbt-ai/dbt-ai-faqs
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/dbt-ai/wizard-how-it-works
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/dbt-extension-features
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/dbt-versions/compatible-track-changelog
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/01-upgrading-to-v2
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/03-upgrading-to-v1.12
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/04-upgrading-to-v1.11
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/05-upgrading-to-v1.10
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/06-upgrading-to-v1.9
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/dbt-versions/product-lifecycles
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/dbt-versions/release-notes
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/dbt-versions/release-tracks
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/dbt-versions/upgrade-dbt-platform-version
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/dbt/dbt-readiness
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/dbt/get-started-dbt
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/explore/dbt-insights
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/install-dbt-extension
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/local/install-dbt-2-oss
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/platform-integrations/downstream-exposures-tableau
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/platform-integrations/orchestrate-exposures
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/platform/about-platform/access-regions-ip-addresses
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/platform/connect-data-platform/about-connections
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/platform/connect-data-platform/connect-teradata
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/platform/manage-access/about-access
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/platform/manage-access/enterprise-permissions
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/platform/secure/private-connectivity/aws/redshift
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/platform/studio-ide/autofix-deprecations
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/platform/studio-ide/lint-format
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/platform/wizard-platform
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/docs/sign-in-dbt-extension
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/guides/_config
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/guides/dbt-platform-local-workflow
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/guides/dbt-upgrade-prepare
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/guides/dbt-upgrade
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/guides/mf-time-spine
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/guides/migrate-off-legacy-dbt-versions
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-changes
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/allow_jinja_file_extensions
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/enable_truthy_nulls_equals_macro
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/latest_version_pointer_enabled_by_default
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_all_warnings_handled_by_warn_error
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_batched_execution_for_custom_microbatch_strategy
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_corrected_analysis_fqns
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_explicit_package_overrides_for_builtin_materializations
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_generic_test_arguments_property
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_nested_cumulative_type_params
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_ref_searches_node_package_before_root
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_resource_names_without_spaces
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_source_and_semantic_model_names_without_spaces
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_sql_header_in_test_configs
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_unique_project_resource_names
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_valid_schema_from_generate_schema_name
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_yaml_configuration_for_mf_time_spines
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/skip_nodes_if_on_run_start_fails
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/source_freshness_run_project_hooks
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/state_modified_compare_more_unrendered_values
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/global-configs/behavior-flags/validate_macro_args
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/metric-properties
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/resource-configs/athena-configs
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/resource-configs/compute
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/resource-configs/databricks-configs
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/resource-configs/snapshots-jinja-legacy
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/resource-configs/static-analysis
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/resource-configs/target_database
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/resource-configs/target_schema
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/resource-configs/unique_key
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/resource-properties/config
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/resource-properties/constraints
- https://docs-getdbt-com-git-nfiann-s3tableathena-dbt-labs.vercel.app/reference/resource-properties/unit-tests

<!-- end-vercel-deployment-preview -->