### PR TITLE
Restructure local unit tests section and add compute applicability badge

### DIFF
--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -73,6 +73,20 @@ That gives you:
 - Queries that execute with the same functions and runtime semantics as the remote warehouse
 - Your data platform's compute left for building models.
 
+### Prerequisites
+
+- Snowflake or BigQuery. Local execution isn't available for other data platforms, and it only applies to unit tests.
+- The direct upstream models of the model you're testing already exist in your data platform. dbt fetches their schemas to translate your SQL, so if they don't exist, the test fails with an error about fetching the upstream relation schema.
+- `static_analysis` isn't set to `off` on the test. Local execution needs static analysis to translate your SQL, so `compute: local` promotes [static analysis](/reference/resource-configs/static-analysis) to `strict` for that test. If you set `static_analysis: off`, the test can't run locally and fails with `ExecutorFailed (dbt1401)`.
+
+### What to know before you use it
+
+- dbt fetches upstream schemas the first time you run the test, then caches them. Later runs reuse the cache, so they don't re-fetch.
+- Local execution only works if dbt can compile your model's SQL and translate it to DuckDB. Complex SQL and functions specific to your data platform might have no DuckDB equivalent so Snowflake's `AI_CLASSIFY` and `haversine` are two examples. So for example, a model that calls `haversine` fails with `failed in db_runner: Internal: Catalog Error: Scalar Function with name haversine does not exist!`.
+- A translation failure is a test failure. `local` doesn't fall back to your data platform, so the test fails and dbt exits with a non-zero code. 
+
+### How to configure
+
 You can configure it on a single unit test:
 
 <File name='models/schema.yml'>
@@ -111,18 +125,6 @@ unit_tests:
 </SimpleTable>
 
 You might also see `sidecar` in error messages but it means the same thing as `local`.
-
-### Prerequisites
-
-- Snowflake or BigQuery. Local execution isn't available for other data platforms, and it only applies to unit tests.
-- The direct upstream models of the model you're testing already exist in your data platform. dbt fetches their schemas to translate your SQL, so if they don't exist, the test fails with an error about fetching the upstream relation schema.
-- `static_analysis` isn't set to `off` on the test. Local execution needs static analysis to translate your SQL, so `compute: local` promotes [static analysis](/reference/resource-configs/static-analysis) to `strict` for that test. If you set `static_analysis: off`, the test can't run locally and fails with `ExecutorFailed (dbt1401)`.
-
-### What to know before you use it
-
-- dbt fetches upstream schemas the first time you run the test, then caches them. Later runs reuse the cache, so they don't re-fetch.
-- Local execution only works if dbt can compile your model's SQL and translate it to DuckDB. Complex SQL and functions specific to your data platform might have no DuckDB equivalent so Snowflake's `AI_CLASSIFY` and `haversine` are two examples. So for example, a model that calls `haversine` fails with `failed in db_runner: Internal: Catalog Error: Scalar Function with name haversine does not exist!`.
-- A translation failure is a test failure. `local` doesn't fall back to your data platform, so the test fails and dbt exits with a non-zero code. 
 
 </VersionBlock>
 

--- a/website/docs/reference/resource-configs/compute.md
+++ b/website/docs/reference/resource-configs/compute.md
@@ -2,13 +2,20 @@
 resource_types: [unit tests]
 title: "compute"
 description: "Use the compute config to run unit tests locally with DuckDB instead of against your data platform."
-intro_text: "Compute controls whether a unit test runs against your data platform or locally with DuckDB."
 datatype: string
 default_value: remote
 sidebar_label: "compute"
+availability:
+  engine: v2
 ---
 
 # compute <Lifecycle status="beta" />
+
+<IntroText>
+
+Compute controls whether a unit test runs against your data platform or locally with DuckDB.
+
+</IntroText>
 
 :::info Available in v2
 


### PR DESCRIPTION
Fast follows on #9950.

## What changed

**`unit-tests.md`** &mdash; reordered the `Run unit tests locally` section so the prerequisites and caveats come before the configuration examples:

- `### Prerequisites` and `### What to know before you use it` moved up, directly after the "That gives you" list
- New `### How to configure` heading, with the "You can configure it on a single unit test" example right after it
- The `compute` values table and the `sidecar` note now sit under **How to configure**

Content moved as-is &mdash; no rewording.

**`compute.md`**

- Added a v2 applicability badge (`availability: engine: v2`), which renders as "Available in v2"
- Moved `intro_text` out of the frontmatter and into an `<IntroText>` component

## Preview

- [Run unit tests locally](https://docs-getdbt-com-git-fast-follow-local-unit-tests-structure-dbt-labs.vercel.app/docs/build/unit-tests#run-unit-tests-locally)
- [compute](https://docs-getdbt-com-git-fast-follow-local-unit-tests-structure-dbt-labs.vercel.app/reference/resource-configs/compute?version=2)