### PR TITLE
Hide rendered UI-only elements (glyphs, pills, icons from callsout, etc) from Markdown

### DIFF
--- a/website/src/components/fusionReleases/index.js
+++ b/website/src/components/fusionReleases/index.js
@@ -234,7 +234,10 @@ export default function FusionReleases() {
 
       <h3>All releases</h3>
 
-      <div className={styles.controls}>
+      {/* Client-side search/filter controls -- interactive chrome with no place
+          in a static Markdown export; data-md-hide drops it from the generated
+          Markdown while the rendered page keeps it. */}
+      <div className={styles.controls} data-md-hide="true">
         <input
           type="text"
           className={styles.searchInput}
@@ -273,7 +276,7 @@ export default function FusionReleases() {
         </div>
       </div>
 
-      <div className={styles.resultCount}>
+      <div className={styles.resultCount} data-md-hide="true">
         Showing {filteredReleases.length} of {sortedReleases.length} releases
       </div>
 

--- a/website/src/components/quickstartGuideCard/index.js
+++ b/website/src/components/quickstartGuideCard/index.js
@@ -179,7 +179,11 @@ export function QuickstartGuideTitle({ frontMatter }) {
         </div>
       </div>
       {(tags || level) && (
-        <div className={styles.tag_container}>
+        // data-md-hide keeps the tags/level pills on the rendered guide but
+        // drops them (via rehypeMdHide) from the generated Markdown, where
+        // they came out as orphan lines ("dbt Fusion engine", "Quickstart",
+        // "Beginner") with no surrounding context.
+        <div className={styles.tag_container} data-md-hide="true">
           {tags &&
             tags.map((tag, i) => (
               <div className={`${styles.tag} tag`} key={i}>

--- a/website/src/components/versionCallout/index.js
+++ b/website/src/components/versionCallout/index.js
@@ -8,7 +8,14 @@ const VersionCallout = ({ version }) => {
 
   return (
   <div>
-    <Admonition type="tip" icon="💡" title="Did you know...">
+    <Admonition
+      type="tip"
+      // data-md-hide keeps the emoji on the rendered callout but strips it from
+      // the generated Markdown, where a bare string icon (unlike the default
+      // aria-hidden SVG admonition icons) leaked as "💡Did you know...".
+      icon={<span data-md-hide="true">💡</span>}
+      title="Did you know..."
+    >
       <span>
         Available from dbt v{version} or with the{' '}
         <a href="/docs/dbt-versions/dbt-release-tracks">

--- a/website/src/theme/DocCard/index.js
+++ b/website/src/theme/DocCard/index.js
@@ -60,7 +60,12 @@ function CardLayout({href, icon, title, description, hoverSnippet}) {
         )}
         title={title}
       >
-        {icon} {title}
+        {/* The icon is a decorative theme glyph (📄️/🗃️/🔗). data-md-hide keeps
+            it on the rendered site but strips it (via rehypeMdHide) from the
+            generated per-page markdown, where it was leaking into card-list
+            headings as `## [📄️ Title](...)`. */}
+        <span data-md-hide="true">{icon} </span>
+        {title}
       </Heading>
       {description && (
         <p


### PR DESCRIPTION
## What are you changing in this pull request and why?

Follow-up to #9765 and #9868.

Rendered-only UI elements still leak into generated Markdown. None of them are content, they're things like theme glyphs, pills, and controls that only make sense on the HTML page.

This covers four cases:

1. DocCard theme glyphs (`📄️`, `🗃️`, and `🔗`) become part of card headings. [category/project-configs.md](https://docs.getdbt.com/category/project-configs.md): `## [📄️ dbt_project.yml](...)` -> `## [dbt_project.yml](...)`.
2. Guide product and difficulty pills become orphan lines. e.g. [guides/fusion.md](https://docs.getdbt.com/guides/fusion.md): a run of `dbt Fusion engine` / `dbt platform` / `Quickstart` / `Beginner` under the title.
3. The VersionCallout text icon (`💡`) is emitted directly before the callout title. (~33 pages). [snapshot_meta_column_names.md](https://docs.getdbt.com/reference/resource-configs/snapshot_meta_column_names.md).
4. Fusion release search, filters, and result counts appear as page content on [fusion-releases.md](https://docs.getdbt.com/docs/fusion/fusion-releases.md).

### How

Each is marked `data-md-hide` at its root (or, for the DocCard icon, the icon is wrapped in a `<span data-md-hide="true">` so the site keeps the glyph). `rehypeMdHide` drops them from the `.md` only; the rendered site is unchanged in every case.

Verified with a local build: the icons, pills, callout emoji, and filter controls are gone from the generated `.md`.

## Checklist

- [x] Build tooling only; no content changes.
- [ ] Versioning rules -- not applicable.
- [ ] Release note -- not applicable.
