### PR TITLE
Adding env var for local unit tests

### DIFF
--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -62,7 +62,7 @@ dbt test --select "test_type:unit"
 
 ## Run unit tests locally <Lifecycle status="beta" />
 
-:::Note Opt in with an environment variable
+:::note Opt in with an environment variable
 
 Running an individual unit test on local compute is currently in beta. Set `DBT_ENGINE_EXPERIMENTAL_LOCAL_UNIT_TESTS=true` in the environment where dbt runs before you use `compute: local`.
 

--- a/website/docs/docs/build/unit-tests.md
+++ b/website/docs/docs/build/unit-tests.md
@@ -62,6 +62,12 @@ dbt test --select "test_type:unit"
 
 ## Run unit tests locally <Lifecycle status="beta" />
 
+:::Note Opt in with an environment variable
+
+Running an individual unit test on local compute is currently in beta. Set `DBT_ENGINE_EXPERIMENTAL_LOCAL_UNIT_TESTS=true` in the environment where dbt runs before you use `compute: local`.
+
+:::
+
 You can run unit tests locally when you're working through tricky SQL and you want to know right away whether your logic works. By default, each unit test sends a query to your data platform and waits for the result. This can slow down testing and use warehouse compute.
 
 Because unit tests use static fixtures instead of real data, they don’t need to necessarily run on your data platform. Use the [`compute: local` config](/reference/resource-configs/compute) to run them locally with DuckDB for faster feedback _without_ the warehouse compute cost.
@@ -75,6 +81,7 @@ That gives you:
 
 ### Prerequisites
 
+- The `DBT_ENGINE_EXPERIMENTAL_LOCAL_UNIT_TESTS` environment variable set to `true`. This config is in beta and you need to opt in. Without it, dbt fails with an invalid configuration error that names the variable.
 - Snowflake or BigQuery. Local execution isn't available for other data platforms, and it only applies to unit tests.
 - The direct upstream models of the model you're testing already exist in your data platform. dbt fetches their schemas to translate your SQL, so if they don't exist, the test fails with an error about fetching the upstream relation schema.
 - `static_analysis` isn't set to `off` on the test. Local execution needs static analysis to translate your SQL, so `compute: local` promotes [static analysis](/reference/resource-configs/static-analysis) to `strict` for that test. If you set `static_analysis: off`, the test can't run locally and fails with `ExecutorFailed (dbt1401)`.
@@ -87,7 +94,13 @@ That gives you:
 
 ### How to configure
 
-You can configure it on a single unit test:
+First, opt in to the config in the environment where dbt runs:
+
+```bash
+export DBT_ENGINE_EXPERIMENTAL_LOCAL_UNIT_TESTS=true
+```
+
+Then you can configure it on a single unit test:
 
 <File name='models/schema.yml'>
 

--- a/website/docs/docs/dbt-versions/dbt-upgrade/01-upgrading-to-v2.md
+++ b/website/docs/docs/dbt-versions/dbt-upgrade/01-upgrading-to-v2.md
@@ -95,7 +95,7 @@ For full usage, refer to [About dbt docs commands](/reference/commands/cmd-docs)
 
 v2 introduces the [`compute`](/reference/resource-configs/compute) config for unit tests. Set your unit tests with `compute: local` and dbt runs the test with DuckDB instead of sending it to your data platform, which takes the warehouse round trip out of your development loop.
 
-This config is opt-in. For details, refer to [Run unit tests locally](/docs/build/unit-tests#run-unit-tests-locally).
+This config is in beta and requires opt-in: set `DBT_ENGINE_EXPERIMENTAL_LOCAL_UNIT_TESTS=true` in the environment where dbt runs before you use `compute: local`. For details, refer to [Run unit tests locally](/docs/build/unit-tests#run-unit-tests-locally).
 
 ### Changed functionality
 

--- a/website/docs/reference/resource-configs/compute.md
+++ b/website/docs/reference/resource-configs/compute.md
@@ -24,9 +24,22 @@ The `compute` config is available in v2 only. It isn't available in v1 and will 
 :::
 
 
+
 By default, each unit test sends a query to your data platform and waits for the result. This can slow down testing and use warehouse compute.
 
 Use the `compute: local` config to run [unit tests](/docs/build/unit-tests) locally with DuckDB for faster feedback while you develop while managing warehouse compute cost. 
+
+:::note Opt in required with an environment variable
+
+Setting `compute: local` on a unit test is in beta. Set the `DBT_ENGINE_EXPERIMENTAL_LOCAL_UNIT_TESTS` environment variable to `true` before you use it:
+
+```bash
+export DBT_ENGINE_EXPERIMENTAL_LOCAL_UNIT_TESTS=true
+```
+
+Without it, dbt fails with an invalid configuration error that names the variable.
+
+:::
 
 <File name='models/filename.yml'>
 
@@ -91,6 +104,7 @@ unit_tests:
 
 #### Things to know about local execution
 
+- `compute: local` is refused unless `DBT_ENGINE_EXPERIMENTAL_LOCAL_UNIT_TESTS=true` is set in the environment where dbt runs. This applies whether you set it on an individual test or as `+compute: local` in `dbt_project.yml`.
 - Your SQL has to be translatable to DuckDB. Platform-specific functions with no DuckDB equivalent fail, and `local` doesn't fall back to your data platform &mdash; a translation failure is a test failure.
 - To translate your SQL, dbt fetches the schemas of your model's direct upstream models from your data platform the first time you run the test, then caches them for later runs. Those upstream models must already exist in your data platform.
 - Setting `compute: local` also promotes [`static_analysis`](/reference/resource-configs/static-analysis) to `strict` for that test, because local execution needs strict analysis to translate your SQL. If you set `static_analysis: off` on the test, it can't run locally and produces an error.

--- a/website/docs/reference/resource-configs/static-analysis.md
+++ b/website/docs/reference/resource-configs/static-analysis.md
@@ -400,6 +400,8 @@ Setting [`compute: local`](/reference/resource-configs/compute) on a unit test (
 
 If you set `static_analysis: off` on a unit test that's configured to run locally, the test can't run and fails with `ExecutorFailed (dbt1401)`. Use `compute: remote` for that test instead.
 
+`compute: local` is in beta and requires the `DBT_ENGINE_EXPERIMENTAL_LOCAL_UNIT_TESTS` environment variable set to `true`, so this interaction only applies once you've opted in.
+
 </VersionBlock>
 
 ### Configure static analysis for seeds

--- a/website/docs/reference/resource-properties/unit-tests.md
+++ b/website/docs/reference/resource-properties/unit-tests.md
@@ -30,7 +30,7 @@ unit_tests:
       meta: {dictionary}
       tags: <string> | [<string>]
       enabled: {boolean} # optional. v1.9 or higher. If not configured, defaults to `true`
-      compute: local | remote # optional. v2.0 or higher. Defaults to `remote`. See [Run unit tests locally](/docs/build/unit-tests#run-unit-tests-locally)
+      compute: local | remote # optional. v2.0 or higher. Defaults to `remote`. `local`in beta and requires DBT_ENGINE_EXPERIMENTAL_LOCAL_UNIT_TESTS=true. See [Run unit tests locally](/docs/build/unit-tests#run-unit-tests-locally)
     given:
       - input: <ref_or_source_call> # optional for seeds
         format: dict | csv | sql


### PR DESCRIPTION
## What are you changing in this pull request and why?

Local execution of unit tests has been gated behind an environment variable.
This PR documents the variable across docs pages that mention the local unit test config
More info [here](https://github.com/dbt-labs/fs/pull/14716)

## Checklist
<!-- Ensure your PR meets the following items. Feel free to add additional checklist items to the list if additional checks need to happen before the PR is merged, such as:
- [ ] Needs technical review
- [ ] Change base branch
- [ ] Merge on xyz date
-->
- [ ] The changes in this PR meet the [docs style guide/fundamentals](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/content-style-guide.md) required for all content.
- [ ] Applied the proper versioning rules if the content is for specific dbt version(s): ([version a whole page](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#adding-a-new-version) or [version a block of content](https://github.com/dbt-labs/docs.getdbt.com/blob/current/contributing/single-sourcing-content.md#versioning-blocks-of-content)
- [ ] The content in this PR requires a dbt release note, so I added one to the [release notes page](https://docs.getdbt.com/docs/dbt-versions/release-notes).).
<!--
PRE-RELEASE VERSION OF dbt (if so, uncomment):
- [ ] Add a note to the prerelease version [Migration Guide](https://github.com/dbt-labs/docs.getdbt.com/tree/current/website/docs/docs/dbt-versions/core-upgrade)
-->
<!-- 
ADDING OR REMOVING PAGES (if so, uncomment):
- [ ] Add/remove page in `website/sidebars.js`
- [ ] Provide a unique filename for new pages
- [ ] Add an entry for deleted pages in `website/vercel.json`
- [ ] Run link testing locally with `npm run build` to update the links that point to deleted pages
-->

<!-- vercel-deployment-preview -->
---
🚀 Deployment available! Here are the direct links to the updated files:


- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/best-practices/best-practice-workflows
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/best-practices/how-to-use-wizard/wizard-6-production-deferral
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/best-practices/how-to-use-wizard/wizard-7-semantic-layer
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/best-practices/how-we-handle-real-time-data/2-incremental-patterns
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/best-practices/how-we-mesh/mesh-5-faqs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/best-practices/how-we-style/1-how-we-style-our-dbt-models
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/best-practices/materializations/materializations-guide-6-examining-builds
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/best-practices/optimize-static-analysis-for-development-and-deployment
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/about-dbt-extension
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/about-dbt-lsp
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/about-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/about-metricflow
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/about-static-analysis
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/custom-schemas
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/data-tests
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/dbt-tips
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/dimensions
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/documentation
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/empty-flag
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/hooks-operations
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/iceberg/adapters/duckdb-iceberg-support
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/iceberg/adapters/snowflake-iceberg-support
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/iceberg/catalogs-yml
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/incremental-microbatch
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/join-logic
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/latest-metrics-spec
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/materializations
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/measures
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/metricflow-commands
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/metricflow-time-spine
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/models
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/ossie-semantic-models
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/packages
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/python-models
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/semantic-models
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/snapshots
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/sources
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/sql-models
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/udfs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/unit-tests
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/validation
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/build/view-documentation
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/community-adapters
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/configure-dbt-extension
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/connect-adapters
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/contribute-dbt-adapters-v2
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/contribute-dbt-adapters
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-ai/integrate-mcp-cursor
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-ai/mcp-available-tools
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-ai/mcp-environment-variables
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-ai/setup-local-mcp
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-ai/setup-remote-mcp
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-ai/wizard-cli-reference
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-ai/wizard-quickstart
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-ai/wizard-skills
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-ai/wizard-slash-commands
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-ai/wizard-subagents
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-licensing
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-support
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/2022-release-notes
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/2023-release-notes
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/2024-release-notes
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/2025-release-notes
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/about-versions
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/compatible-track-changelog
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/01-upgrading-to-v2
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/03-upgrading-to-v1.12
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/04-upgrading-to-v1.11
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/05-upgrading-to-v1.10
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/06-upgrading-to-v1.9
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/07-upgrading-to-v1.8
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/08-upgrading-to-v1.7
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/11-Older
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/versions/09-upgrading-to-v1.6
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/11-Older
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/versions/10-upgrading-to-v1.5
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/11-Older
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/versions/12-upgrading-to-v1.4
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/11-Older
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/versions/13-upgrading-to-v1.3
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/11-Older
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/versions/14-upgrading-to-v1.2
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/11-Older
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/versions/15-upgrading-to-v1.1
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/11-Older
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/versions/16-upgrading-to-v1.0
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/dbt-upgrade/11-Older
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/versions/upgrading-to-dbt-utils-v1.0
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/dbt-version-compatibility
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/dbt-versions
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/product-lifecycles
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/release-notes
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/release-notes/98-dbt-cloud-changelog-2021
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/release-tracks
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt-versions/upgrade-dbt-platform-version
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt/about-dbt-install
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt/adbc
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt/dbt-availability
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt/dbt-readiness
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt/dbt-releases
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt/supported-features
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/dbt/vs-compare-changes
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/deploy/advanced-ci
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/deploy/dbt-state-about
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/deploy/dbt-state-examples
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/deploy/dbt-state-interface
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/deploy/dbt-state-migration
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/deploy/dbt-state-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/deploy/deploy-environments
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/deploy/deployment-tools
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/deploy/hybrid-projects
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/deploy/hybrid-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/deploy/job-commands
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/deploy/run-visibility
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/deploy/state-aware-about
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/deploy/state-aware-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/environments-in-dbt
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/explore/build-and-view-your-docs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/explore/cost-insights
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/explore/dbt-explorer-faqs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/explore/dbt-insights
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/explore/explore-projects
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/get-started-dbt
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/introduction
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/about-local
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/about-dbt-connections
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/alloydb-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/athena-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/azuresynapse-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/bigquery-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/clickhouse-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/confluent-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/cratedb-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/databend-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/databricks-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/decodable-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/deltastream-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/doris-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/dremio-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/duckdb-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/exasol-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/extrica-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/fabric-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/fabricspark-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/firebolt-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/glue-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/greenplum-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/hive-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/hologres-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/ibm-db2-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/ibmnetezza-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/impala-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/infer-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/iomete-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/lakebase-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/layer-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/materialize-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/maxcompute-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/mindsdb-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/mssql-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/mysql-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/oracle-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/postgres-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/redshift-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/risingwave-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/rockset-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/salesforce-data-cloud-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/singlestore-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/snowflake-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/spark-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/sqlite-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/starrocks-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/teradata-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/tidb-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/trino-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/upsolver-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/vertica-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/watsonx-presto-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/watsonx-spark-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/ydb-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/connect-data-platform/yellowbrick-setup
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/dbt-networking-requirements
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/install-dbt-2-oss
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/local/install-dbt
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/mesh/govern/model-contracts
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/mesh/govern/model-versions
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/optimize-builds
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/platform-integrations/downstream-exposures-tableau
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/platform-integrations/orchestrate-exposures
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/platform-integrations/overview
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/platform/about-develop-dbt
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/platform/cloud-cli-installation
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/platform/connect-data-platform/about-connections
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/platform/connect-data-platform/connect-bigquery
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/platform/connect-data-platform/connect-databricks
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/platform/connect-data-platform/connect-redshift
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/platform/connect-data-platform/connect-salesforce
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/platform/connect-data-platform/connect-snowflake
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/platform/manage-access/enterprise-permissions
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/platform/platform-cli-migration
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/platform/studio-ide/autofix-deprecations
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/platform/studio-ide/develop-in-studio
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/platform/studio-ide/ide-user-interface
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/running-a-dbt-project/run-your-dbt-projects
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/running-a-dbt-project/using-threads
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/upgrade-to-dbt-extension
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/use-dbt-semantic-layer/exports
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/use-dbt-semantic-layer/sl-architecture
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/docs/use-dbt-semantic-layer/sl-faqs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/faqs/Core/install-pip-best-practices
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/faqs/Core/install-pip-os-prereqs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/faqs/Core/install-python-compatibility
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/faqs/Environments/diff-database-environment
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/faqs/Environments/profile-name
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/faqs/Environments/target-names
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/faqs/Git/branch-migration
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/faqs/Project/which-schema
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/faqs/Project/why-version-2
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/faqs/Runs/sao-difference-core
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/faqs/State/state-modified-difference
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/_config
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/adapter-creation-v2
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/adapter-creation
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/bigquery-qs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/building-packages
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/databricks-qs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/databricks-workflows
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/dbt-migration-1
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/dbt-migration-2
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/dbt-migration-3
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/dbt-models-on-databricks
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/dbt-package-compat
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/dbt-platform-local-workflow
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/dbt-python-snowpark
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/dbt-qs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/dbt-upgrade-prepare
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/dbt-upgrade
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/debug-errors
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/debug-schema-names
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/dremio-lakehouse
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/duckdb-qs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/iceberg-guide
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/manual-install-qs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/mf-time-spine
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/migrate-from-spark-to-databricks
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/migrate-from-stored-procedures
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/migrate-off-legacy-dbt-versions
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/productionize-your-dbt-databricks-project
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/redshift-qs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/set-up-your-databricks-dbt-project
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/snowflake-qs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/terminal-guide
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/using-jinja
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/zapier-ms-teams
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/guides/zapier-slack
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/artifacts/dbt-artifacts
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/artifacts/manifest-json
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/artifacts/sl-manifest
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/changes-overview
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/commands/build
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/commands/cmd-docs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/commands/compile
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/commands/debug
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/commands/init
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/commands/lint
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/commands/login
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/commands/retry
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/commands/run-operation
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/commands/show
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/commands/state-explain
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/commands/system
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/commands/version
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/data-test-configs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/dbt-commands
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/dbt-jinja-functions/builtins
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/dbt-jinja-functions/config
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/dbt-jinja-functions/debug-method
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/dbt-jinja-functions/dispatch
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/dbt-jinja-functions/doc
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/dbt-jinja-functions/env_var
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/dbt-jinja-functions/flags
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/dbt-jinja-functions/log
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/dbt-jinja-functions/model
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/dbt-jinja-functions/run_query
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/dbt_project.yml
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/deprecations
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/events-logging
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/behavior-changes
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_all_warnings_handled_by_warn_error
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_batched_execution_for_custom_microbatch_strategy
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_explicit_package_overrides_for_builtin_materializations
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_nested_cumulative_type_params
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_ref_searches_node_package_before_root
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_resource_names_without_spaces
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/behavior-flags/require_yaml_configuration_for_mf_time_spines
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/behavior-flags/skip_nodes_if_on_run_start_fails
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/behavior-flags/source_freshness_run_project_hooks
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/behavior-flags/state_modified_compare_more_unrendered_values
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/behavior-flags/validate_macro_args
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/command-line-options
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/indirect-selection
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/parsing
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/resource-type
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/snowflake-changes
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/static-analysis-flag
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/usage-stats
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/user-settings
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/global-configs/warnings
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/metric-properties
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/node-selection/methods
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/node-selection/state-comparison-caveats
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/node-selection/yaml-selectors
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/programmatic-invocations
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/project-configs/quoting
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/project-configs/require-dbt-version
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/project-configs/snapshot-paths
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/project-configs/version
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/references-overview
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/athena-configs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/bigquery-configs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/bigquery-function-support
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/compute
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/contract
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/databricks-configs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/duckdb-configs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/enabled
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/exasol-configs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/freshness
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/invalidate_hard_deletes
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/lag-tolerance
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/metadata-warehouse
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/redshift-configs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/salesforce-data-cloud-configs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/snowflake-configs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/snowflake-function-support
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/sql_header
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/static-analysis
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/target_database
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/target_schema
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-configs/type
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-properties/anchors
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-properties/arguments
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-properties/constraints
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-properties/description
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-properties/freshness
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/resource-properties/unit-tests
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/snapshot-configs
- https://docs-getdbt-com-git-local-tests-dbt-labs.vercel.app/reference/telemetry-observability

<!-- end-vercel-deployment-preview -->